### PR TITLE
Re-design: full architectural specification + docs + roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,26 +2,94 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
+## What this is
 
-- Build: `cargo build` (or `cargo build --release`)
-- Run (stdio transport): `cargo run stdio`
-- Run (http transport, port 3000): `cargo run httpstream`
-- Tests (all): `cargo test`
-- Single test: `cargo test <name>` — e.g. `cargo test test_roll_dice_custom_range`
+`dm-mcp` is an MCP (Model Context Protocol) toolkit for an AI Dungeon Master running solo RPG campaigns. The consumer is always an LLM DM agent — tool responses are structured JSON; narration is the agent's job.
 
-The binary requires a transport argument (`stdio` or `httpstream`); it will exit with a usage message otherwise.
+## Status & where to start
 
-## Architecture
+**Pre-MVP.** The `main` branch carries a dice-rolling stub; the `feature/re-design` branch holds the full architectural design and the phased implementation plan.
 
-Small Rust binary. `src/main.rs` parses `argv[1]` and dispatches to one of two transport modules. All dice logic lives in `src/dice.rs` and is transport-agnostic; transports call into it and serialize `RollResult` as JSON.
+Design is **complete** and documented in [`docs/`](docs/README.md) — organised by area (architecture, event log, characters, checks, items, world, encounters, NPCs, campaign setup, content, IP/licensing). Every decision includes rationale.
 
-- `dice.rs` — core logic. `roll_dice(&str)` accepts three input shapes: `"d6"`-style single die, `"3d6"`-style multi-dice (returns per-die `results` plus summed `result`), and `"11-52"`-style custom inclusive range. `roll_multiple_dice_request` is the explicit multi-dice API. Unknown dice strings silently default to `d20` — `parse_dice_type` returns `u32` (not `Result`), so invalid input produces a valid roll rather than an error.
-- `stdio.rs` — line-buffered loop over stdin. **Duplicates multi-dice parsing** that already exists in `dice.rs`: it splits on `'d'` itself and calls `roll_multiple_dice_request` directly, rather than letting `roll_dice` handle the `"NdM"` case. Keep this in mind when changing the multi-dice parser — there are two call sites.
-- `httpstream.rs` — **stub, not a working HTTP server.** Despite the README's API documentation, this function only prints a placeholder message and returns. The hyper/rustls dependencies are declared but unused. Implementing the real HTTP server is an open task, not a maintained feature.
+Implementation is **in progress** via 10 small, testable phases tracked in the [README.md Roadmap](README.md#roadmap).
 
-## Gotchas
+**If you're starting a fresh session and don't know what to do:** read the Roadmap, find the next unchecked phase, and follow the per-phase workflow documented below the table.
 
-- **`rust-mcp-sdk` / `rust-mcp-transport` in `Cargo.toml` are unused.** Nothing in `src/` imports them. The project is named "MCP server" but currently speaks plain newline-delimited JSON on stdio — it is not an MCP protocol implementation. Re-adding real MCP support is likely on the roadmap; don't assume existing scaffolding is in place.
-- **`src/dice_test.rs` is dead code.** It is not declared as a module in `main.rs` and its contents reference an older API (`parse_dice_type` returning `Result`, a `RollRequest` with `die_type`/`min_value`/`max_value` fields) that no longer exists. The live tests are the `#[cfg(test)] mod tests` block at the bottom of `dice.rs`. Don't trust `dice_test.rs` as a spec — if you wire it up, it won't compile.
-- `roll_dice` returns `results: None` for single-die and custom-range inputs, and `results: Some(vec)` only for multi-dice. Callers must handle both.
+## Hard rules (non-negotiable)
+
+These affect every coding decision. Do not relax or defer them.
+
+- **TLS via rustls only, never OpenSSL.** The release target is a `scratch` container image. OpenSSL breaks scratch builds. Before adding any dependency that does networking or HTTP, audit its default features and explicitly select a rustls backend (e.g. `rusqlite` features excluding `bundled-sqlcipher`, `reqwest = { features = ["rustls-tls"] }`). If a dep silently pulls `native-tls` or `openssl-sys`, treat it as a build-blocker — swap it or disable default features. Run `cargo tree -i openssl` periodically; non-empty output means something regressed.
+
+- **No WotC trademarks or non-SRD copyrighted text.** See [`docs/ip-and-licensing.md`](docs/ip-and-licensing.md) for the full rule. Never use "D&D", "Dungeons & Dragons", "5e", or "5th Edition" branding in README, docs, code comments, strings, commit messages, or container labels — use "d20-inspired" instead. Content is original or drawn only from the 5.1 SRD (CC-BY-4.0) or ORC-licensed material. No copy-paste of non-SRD product-book text, even mechanically-identical stat blocks.
+
+- **Content is data, not code.** Anything describing "what a thing is" (item definitions, archetype stats, condition riders, biome templates, encounter resolution paths) lives in bundled YAML under `content/`. Only per-instance data lives in SQLite. Before adding a column to support a new rule, ask whether it can live in content instead. Most answers are yes.
+
+- **Latency is a first-class goal.** The MCP sits in the hot path of every player turn. Defaults committed to: SQLite PRAGMAs set at connection open (`journal_mode=WAL`, `synchronous=NORMAL`, `mmap_size`, `cache_size`, `foreign_keys=ON`), prepared-statement caching for every hot query, batched writes per tool call in a single transaction, content parsed once at startup into in-memory structs. Event summaries are code-templated from kind + payload, **never** LLM-generated.
+
+- **One campaign per process.** No multi-tenant logic, no cross-campaign state, no connection pool to a shared DB service. Multi-campaign hosts spawn one process per campaign, one SQLite file per campaign.
+
+- **No alignment axis on species or archetypes.** No "evil orcs." Hostility is situational (role + faction + triggers), not species-intrinsic. Every hostile encounter's content entry carries at least one peaceful `resolution_path` unless all participants are truly mindless. Enforced at content-review time.
+
+## Per-phase workflow
+
+Every phase in the Roadmap follows this loop:
+
+1. Branch off `main` → `feature/phase-N-<name>`.
+2. Implement the phase's tools and supporting code.
+3. Write integration tests in `tests/` covering the E2E assertions listed in the Roadmap table for that phase. Use `cargo test` with subprocess-spawned binary + real MCP client (`rmcp` client-side for stdio; `reqwest` for HTTP). No Playwright — there is no browser surface.
+4. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` — all pass clean.
+5. Update README.md — tick the phase's checkbox in the Roadmap table, link the PR.
+6. Push branch → `gh pr create --base main` with a description summarising scope and assertions.
+
+Do not merge multiple phases in one PR. Each phase is a discrete, reviewable slice.
+
+## Key architectural decisions (pointers)
+
+Full rationale is in [`docs/`](docs/README.md); brief pointers here so a fresh session doesn't relitigate closed questions:
+
+- **Dual transport from day one.** stdio + HTTP via a transport-agnostic `dispatch.rs` core. MCP SDK is `rmcp` (official). See [`docs/architecture.md`](docs/architecture.md).
+- **Single polymorphic `events` table** with JSON payload + `event_participants`/`event_items` junctions. Append-only. Code-templated summaries. See [`docs/history-log.md`](docs/history-log.md).
+- **Two-tier time** — `campaign_hour` (cumulative world-hours, integer, may be negative for pre-campaign backstory) + nullable `combat_round` (6s ticks inside combat). The clocks do not reconcile arithmetically. See [`docs/history-log.md`](docs/history-log.md).
+- **Unified `characters` table** for player, companions, pets, friendly NPCs, enemies. Role is a column, not a table split. Pets use the full schema. See [`docs/characters.md`](docs/characters.md).
+- **Effects never mutate base stats** — they are rows with `modifier` and `dice_expr` that compose at read time. Conditions are separate; their mechanical riders live in `content/rules/conditions.yaml`. See [`docs/checks.md`](docs/checks.md).
+- **Ideology alignment is a universal social-check modifier**, not companion-specific. Tiers fixed in `content/rules/ideology_alignment.yaml`. See [`docs/checks.md`](docs/checks.md).
+- **Graph-of-zones world**, not hex grid. `direction_from` on connections is forward-compat. Lazy generation (stub on adjacency, full on first visit) with a reconciliation pass that prefers existing entities when filling slots. See [`docs/world.md`](docs/world.md).
+- **Goal-not-kills XP.** `encounter.goal_completed` fires XP regardless of path; bypassing an encounter earns the same as fighting it. See [`docs/encounters.md`](docs/encounters.md).
+- **Combat is a mode of an encounter**, not a separate subsystem. `combat.start` auto-ends any other in-combat encounter to prevent stale state. See [`docs/encounters.md`](docs/encounters.md).
+
+## Current stub caveats (removed by Phase 1)
+
+Until Phase 1 merges, these are artifacts of the pre-redesign code:
+
+- `Cargo.toml` declares `rust-mcp-sdk`, `rust-mcp-transport`, `hyper`, `rustls`, `tokio-rustls` — all **unused in `src/`**. Phase 1 replaces with `rmcp` and trims unused deps.
+- `src/httpstream.rs` is a stub that prints a placeholder message instead of serving HTTP.
+- `src/dice_test.rs` is dead code — not declared as a module, references an older API that no longer compiles. Live tests are in the `#[cfg(test)] mod tests` block inside `src/dice.rs`.
+- The existing stdio loop is bespoke newline-delimited JSON, **not** real MCP protocol.
+
+Do not rely on anything the current code seems to imply — treat `main` as "has a working dice roller and that's it."
+
+## Environment / config
+
+Configuration is entirely via `DMMCP_`-prefixed environment variables loaded once at startup into a `Config` struct. The full table lives in [README.md](README.md#configuration). `foreign_keys=ON` is hard-coded for correctness; everything else is tunable.
+
+Default DB path is `./campaign.db`. One campaign per process. Override with `DMMCP_DB_PATH`.
+
+## Build & run (commands)
+
+Standard Cargo — nothing fancy:
+
+```
+cargo build --release
+cargo test
+cargo clippy -- -D warnings
+cargo fmt --check
+```
+
+Runtime:
+
+```
+dm-mcp stdio   # MCP over stdin/stdout
+dm-mcp http    # MCP over HTTP (serves /healthz)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- Build: `cargo build` (or `cargo build --release`)
+- Run (stdio transport): `cargo run stdio`
+- Run (http transport, port 3000): `cargo run httpstream`
+- Tests (all): `cargo test`
+- Single test: `cargo test <name>` — e.g. `cargo test test_roll_dice_custom_range`
+
+The binary requires a transport argument (`stdio` or `httpstream`); it will exit with a usage message otherwise.
+
+## Architecture
+
+Small Rust binary. `src/main.rs` parses `argv[1]` and dispatches to one of two transport modules. All dice logic lives in `src/dice.rs` and is transport-agnostic; transports call into it and serialize `RollResult` as JSON.
+
+- `dice.rs` — core logic. `roll_dice(&str)` accepts three input shapes: `"d6"`-style single die, `"3d6"`-style multi-dice (returns per-die `results` plus summed `result`), and `"11-52"`-style custom inclusive range. `roll_multiple_dice_request` is the explicit multi-dice API. Unknown dice strings silently default to `d20` — `parse_dice_type` returns `u32` (not `Result`), so invalid input produces a valid roll rather than an error.
+- `stdio.rs` — line-buffered loop over stdin. **Duplicates multi-dice parsing** that already exists in `dice.rs`: it splits on `'d'` itself and calls `roll_multiple_dice_request` directly, rather than letting `roll_dice` handle the `"NdM"` case. Keep this in mind when changing the multi-dice parser — there are two call sites.
+- `httpstream.rs` — **stub, not a working HTTP server.** Despite the README's API documentation, this function only prints a placeholder message and returns. The hyper/rustls dependencies are declared but unused. Implementing the real HTTP server is an open task, not a maintained feature.
+
+## Gotchas
+
+- **`rust-mcp-sdk` / `rust-mcp-transport` in `Cargo.toml` are unused.** Nothing in `src/` imports them. The project is named "MCP server" but currently speaks plain newline-delimited JSON on stdio — it is not an MCP protocol implementation. Re-adding real MCP support is likely on the roadmap; don't assume existing scaffolding is in place.
+- **`src/dice_test.rs` is dead code.** It is not declared as a module in `main.rs` and its contents reference an older API (`parse_dice_type` returning `Result`, a `RollRequest` with `die_type`/`min_value`/`max_value` fields) that no longer exists. The live tests are the `#[cfg(test)] mod tests` block at the bottom of `dice.rs`. Don't trust `dice_test.rs` as a spec — if you wire it up, it won't compile.
+- `roll_dice` returns `results: None` for single-die and custom-range inputs, and `results: Some(vec)` only for multi-dice. Callers must handle both.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,39 @@ An MCP (Model Context Protocol) toolkit for AI Dungeon Masters running solo RPG 
 
 ## Status
 
-**Pre-MVP.** Active redesign on branch `feature/re-design`. The main branch currently exposes only a dice-rolling stub over a bespoke stdio JSON loop; nothing below describes the current code. Features listed are the designed product, not the shipped one.
+**Pre-MVP.** Active redesign on branch `feature/re-design`. The main branch still carries a dice-rolling stub; design work for the full toolkit has landed in [`docs/`](docs/README.md) and implementation is underway. Features listed here describe the designed product, not the shipped one.
 
-## What it does (designed)
+## What it does
 
 - **Dice** — d4, d6, d8, d10, d12, d20, d100, arbitrary ranges (`11-43`), multi-dice (`3d6`), modifiers, advantage/disadvantage
-- **World generation** — tag-based biome and encounter tables, hex-grid maps with fog of war, landmarks
-- **Characters** — one unified model for the player, companions (adventurers and pets), and NPCs; skills as rows for flexible progression; loyalty + ideology for obedience mechanics
-- **Items** — base types layered with materials (+1 basic → +5 exotic) and composable enchantments
-- **Checks** — skill-check resolution with modifier stacking (including active temporary effects)
-- **History / event log** — append-only record of everything that happens; seeds NPC backstories, powers recognition scenes ("the villagers recognise this orc"), and backs XP arithmetic
+- **World generation** — tag-based biome and encounter tables, graph-of-zones with fog of war, landmarks, lazy expansion as the player explores
+- **Characters** — one unified model for the player, companions (adventurers and pets), friendly NPCs, and enemies; skills as rows for flexible progression; loyalty + ideology for companion obedience and social-check modifiers
+- **Items** — base types layered with materials (tier 1 basic → tier 5 exotic) and composable enchantments; currency is just items; weight-based encumbrance enforced
+- **Checks** — d20-inspired check resolution with modifier stacking, active effect composition, and condition riders
+- **History / event log** — append-only record of everything that happens; powers NPC backstory generation, recognition scenes, XP arithmetic, and player recall
 - **XP** — awarded on encounter-goal completion (no "kill XP" — stealth past the skeletons earns the same as slaying them) plus DM-discretionary bonuses for clever play
+- **Non-violent resolution** — every hostile encounter carries at least one peaceful path; no "evil by default" species
+- **Campaign bootstrap** — guided setup dialogue at campaign start; world seeded with pre-history events for a lived-in feel from session one
 
 The consumer is always an LLM DM agent. Tool responses are structured JSON; narration is the agent's job.
+
+## Design & documentation
+
+Every architectural decision, schema, and tool is documented in [`docs/`](docs/README.md):
+
+- [Architecture](docs/architecture.md) — transport, deployment, latency, config
+- [History & event log](docs/history-log.md)
+- [Characters, parties & death](docs/characters.md)
+- [Checks, effects & conditions](docs/checks.md)
+- [Items & inventory](docs/items.md)
+- [World, zones & maps](docs/world.md)
+- [Encounters & combat](docs/encounters.md)
+- [NPC generation](docs/npcs.md)
+- [Campaign setup](docs/campaign-setup.md)
+- [Content](docs/content.md)
+- [IP & licensing](docs/ip-and-licensing.md)
+
+If you're modifying the project, read the docs for the area you're touching — they include rationale for the design choices, not just the schema.
 
 ## Build
 
@@ -29,36 +49,37 @@ Pure Rust, rustls-only TLS — the release binary is statically linked and ships
 ## Run
 
 ```bash
-dm-mcp stdio   # MCP over stdin/stdout (fastest; for local DM agents)
-dm-mcp http    # MCP over streamable HTTP (for Kubernetes / networked deploys)
+dm-mcp stdio    # MCP over stdin/stdout (lowest latency; local DM agents)
+dm-mcp http     # MCP over streamable HTTP (networked / Kubernetes deploys)
 ```
 
-One campaign per process. Multi-campaign hosts spawn one process per campaign.
+One campaign per process. Multi-campaign hosts spawn one process per campaign, one SQLite file per campaign.
 
 ## Configuration
 
-Every performance knob has a low-latency default and is overridable via environment variables. Defaults are tuned for the hot path — the MCP sits between every player command and the DM agent's response, so latency compounds with LLM latency.
+Every performance knob has a low-latency default and is overridable via environment variable. Defaults are tuned for the hot path — the MCP sits between every player command and the DM agent's response, so latency compounds with LLM latency.
 
-| Variable                  | Default         | Effect                                                                 |
-|---------------------------|-----------------|------------------------------------------------------------------------|
-| `DMMCP_DB_PATH`           | `./campaign.db` | Path to the SQLite file for this campaign                              |
-| `DMMCP_DB_JOURNAL_MODE`   | `WAL`           | SQLite `journal_mode` PRAGMA. WAL lets reads and writes run concurrently |
-| `DMMCP_DB_SYNCHRONOUS`    | `NORMAL`        | SQLite `synchronous` PRAGMA. `NORMAL` is durable across crashes and faster than `FULL` under WAL |
-| `DMMCP_DB_MMAP_SIZE`      | `67108864`      | SQLite `mmap_size` PRAGMA, bytes. Default 64 MB; raise to 256 MB+ on larger hosts |
-| `DMMCP_DB_CACHE_SIZE`     | `-32768`        | SQLite `cache_size` PRAGMA. Negative values are kilobytes; default is 32 MB |
-| `DMMCP_HTTP_BIND`         | `0.0.0.0`       | HTTP transport bind address                                            |
-| `DMMCP_HTTP_PORT`         | `3000`          | HTTP transport port                                                    |
-| `DMMCP_LOG_LEVEL`         | `info`          | `tracing` log level (`trace`, `debug`, `info`, `warn`, `error`)        |
+| Variable                  | Default         | Effect                                                                                 |
+|---------------------------|-----------------|----------------------------------------------------------------------------------------|
+| `DMMCP_DB_PATH`           | `./campaign.db` | Path to the SQLite file for this campaign                                              |
+| `DMMCP_DB_JOURNAL_MODE`   | `WAL`           | SQLite `journal_mode` PRAGMA. WAL lets readers and writers run concurrently            |
+| `DMMCP_DB_SYNCHRONOUS`    | `NORMAL`        | SQLite `synchronous` PRAGMA. Durable across crashes; meaningfully faster than `FULL` under WAL |
+| `DMMCP_DB_MMAP_SIZE`      | `67108864`      | SQLite `mmap_size` PRAGMA, bytes. Default 64 MB; raise to 256 MB+ on larger hosts      |
+| `DMMCP_DB_CACHE_SIZE`     | `-32768`        | SQLite `cache_size` PRAGMA. Negative values are kilobytes; default is 32 MB            |
+| `DMMCP_HTTP_BIND`         | `0.0.0.0`       | HTTP bind address                                                                      |
+| `DMMCP_HTTP_PORT`         | `3000`          | HTTP port                                                                              |
+| `DMMCP_LOG_LEVEL`         | `info`          | `tracing` log level (`trace`/`debug`/`info`/`warn`/`error`)                            |
+| `DMMCP_CONTENT_DIR`       | *(unset)*       | When set, loads bundled YAML content from disk instead of the baked-in copy            |
 
-`foreign_keys = ON` is hard-coded — that's correctness, not tuning.
+`foreign_keys = ON` is hard-coded — correctness, not tuning.
 
-Tinker at your own risk. The defaults are good for a Raspberry Pi 4 running one campaign; a beefier host can turn `DMMCP_DB_MMAP_SIZE` and `DMMCP_DB_CACHE_SIZE` up for better cache behaviour on large campaigns.
+Tinker at your own risk. The defaults are good for a Raspberry Pi 4 running one campaign; a beefier host can turn `DMMCP_DB_MMAP_SIZE` and `DMMCP_DB_CACHE_SIZE` up for better cache behaviour on large campaigns. See [docs/architecture.md](docs/architecture.md) for the reasoning behind the latency commitments.
 
 ## Kubernetes
 
-The `http` mode exposes `GET /healthz` which returns 200 when the SQLite database is reachable — wire it as both a readiness and liveness probe. Mount the campaign database as a PersistentVolume.
+`http` mode exposes `GET /healthz` which returns 200 when the SQLite database is reachable. Wire it as both a readiness and a liveness probe. Mount the campaign database as a PersistentVolume.
 
-A minimal deployment looks like:
+Minimal deployment:
 
 ```yaml
 containers:

--- a/README.md
+++ b/README.md
@@ -1,88 +1,88 @@
-# Random Number Generator MCP Server
+# dm-mcp
 
-A Rust-based MCP server designed as a toolkit for AI dungeon masters, primarily focused on dice rolling functionality.
+An MCP (Model Context Protocol) toolkit for AI Dungeon Masters running solo RPG campaigns. One human player, an LLM DM, and this server holding the world's persistent state.
 
-## Features
+## Status
 
-- Support for standard dice types: D4, D6, D8, D10, D12, D20, D100
-- Custom range dice rolling (e.g., 11-52)
-- Multiple dice rolling (e.g., 3d6, 5d20) with individual results
-- Both stdio and httpstream transport layers
-- TLS support using rustls instead of OpenSSL
-- Self-contained with no external dependencies
+**Pre-MVP.** Active redesign on branch `feature/re-design`. The main branch currently exposes only a dice-rolling stub over a bespoke stdio JSON loop; nothing below describes the current code. Features listed are the designed product, not the shipped one.
 
-## Usage
+## What it does (designed)
 
-### Running the Server
+- **Dice** — d4, d6, d8, d10, d12, d20, d100, arbitrary ranges (`11-43`), multi-dice (`3d6`), modifiers, advantage/disadvantage
+- **World generation** — tag-based biome and encounter tables, hex-grid maps with fog of war, landmarks
+- **Characters** — one unified model for the player, companions (adventurers and pets), and NPCs; skills as rows for flexible progression; loyalty + ideology for obedience mechanics
+- **Items** — base types layered with materials (+1 basic → +5 exotic) and composable enchantments
+- **Checks** — skill-check resolution with modifier stacking (including active temporary effects)
+- **History / event log** — append-only record of everything that happens; seeds NPC backstories, powers recognition scenes ("the villagers recognise this orc"), and backs XP arithmetic
+- **XP** — awarded on encounter-goal completion (no "kill XP" — stealth past the skeletons earns the same as slaying them) plus DM-discretionary bonuses for clever play
 
-```bash
-# For stdio mode
-cargo run stdio
+The consumer is always an LLM DM agent. Tool responses are structured JSON; narration is the agent's job.
 
-# For httpstream mode (default port 3000)
-cargo run httpstream
-```
-
-### Dice Roll Formats
-
-- Standard dice: `d4`, `d6`, `d8`, `d10`, `d12`, `d20`, `d100`
-- Custom ranges: `11-52` (rolls between 11 and 52)
-- Multiple dice: `3d6` (rolls 3 six-sided dice), `5d20` (rolls 5 twenty-sided dice)
-
-### Transport Layers
-
-#### Stdio Mode
-The server accepts dice roll requests via standard input and outputs results to standard output.
-
-#### Httpstream Mode
-The server runs an HTTP API on port 3000 with a `/roll` endpoint that accepts JSON requests and returns JSON responses.
-
-## API Endpoints
-
-### POST /roll
-
-Request body:
-```json
-{
-  "dice": "d20"
-}
-```
-
-Response:
-```json
-{
-  "result": 15,
-  "dice": "d20",
-  "results": null
-}
-```
-
-For multiple dice rolling, the response includes individual results:
-```json
-{
-  "result": 12,
-  "dice": "3d6",
-  "results": [3, 4, 5]
-}
-```
-
-## Building
+## Build
 
 ```bash
 cargo build --release
 ```
 
-## Dependencies
+Pure Rust, rustls-only TLS — the release binary is statically linked and ships into a `scratch` container with no system dependencies.
 
-- Rust 1.60+
-- tokio
-- serde
-- rand
-- hyper 1.0
-- rustls
-- rust-mcp-sdk 0.8.3
-- rust-mcp-transport 0.8.0
+## Run
 
-## Security
+```bash
+dm-mcp stdio   # MCP over stdin/stdout (fastest; for local DM agents)
+dm-mcp http    # MCP over streamable HTTP (for Kubernetes / networked deploys)
+```
 
-This implementation uses rustls for TLS support instead of OpenSSL, ensuring no external dependencies.
+One campaign per process. Multi-campaign hosts spawn one process per campaign.
+
+## Configuration
+
+Every performance knob has a low-latency default and is overridable via environment variables. Defaults are tuned for the hot path — the MCP sits between every player command and the DM agent's response, so latency compounds with LLM latency.
+
+| Variable                  | Default         | Effect                                                                 |
+|---------------------------|-----------------|------------------------------------------------------------------------|
+| `DMMCP_DB_PATH`           | `./campaign.db` | Path to the SQLite file for this campaign                              |
+| `DMMCP_DB_JOURNAL_MODE`   | `WAL`           | SQLite `journal_mode` PRAGMA. WAL lets reads and writes run concurrently |
+| `DMMCP_DB_SYNCHRONOUS`    | `NORMAL`        | SQLite `synchronous` PRAGMA. `NORMAL` is durable across crashes and faster than `FULL` under WAL |
+| `DMMCP_DB_MMAP_SIZE`      | `67108864`      | SQLite `mmap_size` PRAGMA, bytes. Default 64 MB; raise to 256 MB+ on larger hosts |
+| `DMMCP_DB_CACHE_SIZE`     | `-32768`        | SQLite `cache_size` PRAGMA. Negative values are kilobytes; default is 32 MB |
+| `DMMCP_HTTP_BIND`         | `0.0.0.0`       | HTTP transport bind address                                            |
+| `DMMCP_HTTP_PORT`         | `3000`          | HTTP transport port                                                    |
+| `DMMCP_LOG_LEVEL`         | `info`          | `tracing` log level (`trace`, `debug`, `info`, `warn`, `error`)        |
+
+`foreign_keys = ON` is hard-coded — that's correctness, not tuning.
+
+Tinker at your own risk. The defaults are good for a Raspberry Pi 4 running one campaign; a beefier host can turn `DMMCP_DB_MMAP_SIZE` and `DMMCP_DB_CACHE_SIZE` up for better cache behaviour on large campaigns.
+
+## Kubernetes
+
+The `http` mode exposes `GET /healthz` which returns 200 when the SQLite database is reachable — wire it as both a readiness and liveness probe. Mount the campaign database as a PersistentVolume.
+
+A minimal deployment looks like:
+
+```yaml
+containers:
+  - name: dm-mcp
+    image: dm-mcp:latest      # scratch-based, ~10–20 MB
+    args: ["http"]
+    env:
+      - name: DMMCP_DB_PATH
+        value: /data/campaign.db
+    ports:
+      - containerPort: 3000
+    readinessProbe:
+      httpGet: { path: /healthz, port: 3000 }
+    livenessProbe:
+      httpGet: { path: /healthz, port: 3000 }
+    volumeMounts:
+      - name: campaign
+        mountPath: /data
+volumes:
+  - name: campaign
+    persistentVolumeClaim:
+      claimName: dm-mcp-campaign
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,38 @@ An MCP (Model Context Protocol) toolkit for AI Dungeon Masters running solo RPG 
 
 ## Status
 
-**Pre-MVP.** Active redesign on branch `feature/re-design`. The main branch still carries a dice-rolling stub; design work for the full toolkit has landed in [`docs/`](docs/README.md) and implementation is underway. Features listed here describe the designed product, not the shipped one.
+**Pre-MVP.** Design complete — full rationale in [`docs/`](docs/README.md). Implementation proceeds through the phased [Roadmap](#roadmap) below. The `main` branch still carries the original dice-rolling stub; phase branches land via PR. Features described elsewhere in this README are the designed product; consult the Roadmap for what ships when.
+
+## Roadmap
+
+Implementation is broken into 10 small, testable phases. Each phase ships a vertical slice with E2E integration tests (`cargo test`, subprocess-spawned binary driven through real MCP protocol — see [docs/architecture.md](docs/architecture.md)).
+
+### Per-phase workflow
+
+1. Branch off `main` → `feature/phase-N-<name>`.
+2. Implement the phase's tools and supporting code.
+3. Write integration tests in `tests/` covering the E2E assertion(s) in the table below. Unit-test any non-trivial internal function.
+4. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` — all clean.
+5. Tick the phase's checkbox in the table below and link the PR.
+6. Push branch → `gh pr create --base main` with a description summarising scope and assertions.
+
+Do not merge multiple phases in one PR; each phase is a discrete reviewable slice.
+
+### Phases
+
+| # | Phase | Scope | E2E assertion | Status | PR |
+|---|-------|-------|---------------|--------|----|
+| 1 | **Skeleton** | Binary builds; `dm-mcp stdio` and `dm-mcp http` subcommands; `Config` loaded from `DMMCP_` env vars; HTTP serves `/healthz`; MCP handshake over stdio; trivial `server.info` tool; old stub code, `httpstream.rs`, `dice_test.rs`, and unused deps (`rust-mcp-sdk`, `rust-mcp-transport`, `hyper`, `rustls`, `tokio-rustls`) removed; `rmcp` added. | Spawn HTTP → `GET /healthz` = 200. Spawn stdio → MCP handshake succeeds → `server.info` returns expected shape (version + transport). | ☐ | – |
+| 2 | **DB + content loader** | Schema migrations for all tables from the design; SQLite connection opened with configured PRAGMAs; bundled YAML content for `abilities`, `skills`, `damage_types`, `conditions`, plus one sample biome, weapon base, enchantment, and archetype; content parsed once at startup into typed structs; `content.introspect` tool. | Delete DB file → start server → file exists with all expected tables. `content.introspect` response contains expected content IDs. | ☐ | – |
+| 3 | **Dice** | `dice.roll` tool: standard dice (d4–d100), arbitrary ranges (`11-43`), multi-dice (`3d6`) with per-die results and sum. | `dice.roll("d20")` → result ∈ [1, 20]. `dice.roll("3d6")` → 3 rolls, sum equals total. `dice.roll("11-43")` → result ∈ [11, 43]. | ☐ | – |
+| 4 | **Character core** | `character.create`, `character.get` (effective stats with active effects composed), `character.update_plans`, `character.change_role`; `character_proficiencies` CRUD; `effects` table: `apply_effect`, `dispel_effect`; `character_resources` CRUD. | Create character with STR 14 → `apply_effect(+4 STR)` → `character.get` shows effective 18 → `dispel_effect` → shows 14. Event log has `character.created`, `effect.applied`, `effect.expired`. | ☐ | – |
+| 5 | **Checks** | `resolve_check` composing base + ability mod + proficiency + ranks + effects + conditions + caller modifiers; condition mechanical riders loaded from `content/rules/conditions.yaml`; ideology-alignment modifier threaded via `check_spec.modifiers`. | Apply Bless (`1d4` on checks) → resolve persuasion → breakdown contains rolled bless die. Apply blinded → resolve attack → two d20s rolled, lower taken. Pass `{kind: ideology_alignment, value: -6}` → event payload records the modifier with reason. | ☐ | – |
+| 6 | **Campaign setup + starting zone** | `setup.new_campaign`, `setup.answer`, `setup.generate_world` (starting zone + 2–5 stub neighbours, no NPCs yet), `setup.mark_ready`; `campaign_state` singleton transitions setup → running, `campaign_hour` = 0. | Full setup flow (new → 3 answers → generate → ready) → DB has starting zone matching biome answer, 2–5 stub neighbour zone rows, `campaign_state.phase='running'`, `campaign.started` event at hour 0. | ☐ | – |
+| 7 | **Travel + fog of war** | `world.travel`, `world.map`, `world.describe_zone`; entering a zone triggers stub-generation for missing neighbours; first-visit full generation creates landmarks (NPC placement deferred to Phase 8). | Travel to neighbour → `campaign_hour` advanced by edge's `travel_time_hours`, `character_zone_knowledge.level` = 'visited', `world.map` returns both zones with computed 2D positions and connection. | ☐ | – |
+| 8 | **NPC generation + recall** | `npc.generate` with two committed archetypes (one friendly, one enemy); backstory synthesis with 3–5 events at negative `campaign_hour`; reconciliation pass fills slots from existing characters/zones; `character.recall` with filters; zone full-generation now places NPCs. | Generate orc_raider in a zone → character row has stats in archetype range, proficiencies inserted, loadout items held. Event log has 3–5 `history.backstory` events with `campaign_hour < 0` and the orc as a participant. `character.recall(orc.id)` returns those events. | ☐ | – |
+| 9 | **Encounters + combat + death** | `encounter.create`, `encounter.complete` (XP flow by resolution path), `encounter.abandon`, `encounter.fail`; `combat.start` with stale-combat auto-cleanup, `combat.next_turn` with round-based effect/condition expiry, `combat.end`; `combat.apply_damage` integrates the death flow (`mortally_wounded` at 0 HP → `roll_death_save` → `roll_death_event` on 3 failures); short/long rest tools. | Start encounter → combat → `next_turn` × N with 2-round effect → expired after round 3. Damage to 0 HP → `mortally_wounded` applied, status='unconscious'. Three failed death saves → status='dead' → `roll_death_event` returns a rolled event. Starting a second combat while first still flagged → first auto-ended, `combat.auto_ended` emitted. | ☐ | – |
+| 10 | **Inventory + barter + encumbrance** | Full items tool surface: `inventory.create/transfer/pickup/drop/equip/unequip/get/inspect`; weight computation; encumbrance enforcement (`encumbered` condition between 67% and 100%, pickup refused above 100%); `barter.exchange` with persuasion-check-driven rate. | STR 10 (capacity 150 lb) → pickup 100 lb → no condition. Pickup 10 more → 73% of capacity → `encumbered` applied. Pickup 50 more (would be 160) → refused with `would_overload`. Barter: offer below fair value → persuasion check → success completes, failure → merchant declines. | ☐ | – |
+
 
 ## What it does
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# dm-mcp — Design Documentation
+
+This directory captures every architectural decision made for `dm-mcp`. Each file covers one focused area and explains **what was decided**, **why**, and **what was deferred**.
+
+Read in the order below for a complete picture; or jump to the area you're modifying.
+
+## Foundations
+
+- [Architecture](architecture.md) — Transport layer, MCP SDK, CLI, deployment targets, latency commitments, environment-variable configuration.
+- [History & event log](history-log.md) — The polymorphic `events` table that ties every other subsystem together. Two-tier time model. Query patterns.
+- [Data persistence & content](content.md) — SQLite layout, bundled YAML content directory structure, content hot-swap via `DMMCP_CONTENT_DIR`.
+- [IP & licensing](ip-and-licensing.md) — Hard rules around SRD/ORC-licensed content and avoiding WotC trademarks.
+
+## Entities & mechanics
+
+- [Characters, parties & death](characters.md) — The unified character table that backs the player, companions, pets, and every NPC. Parties. Loyalty. Ideology. Plans. Progression. The three-strike death flow.
+- [Checks, effects & conditions](checks.md) — `resolve_check` composition. Temporary effects (never mutate base stats). Conditions with mechanical riders. Proficiencies. The ideology-alignment modifier rubric.
+- [Items & inventory](items.md) — Single-table item model. Materials and enchantments as layers. Weight + encumbrance enforcement. Currency as items. Barter.
+
+## World
+
+- [World, zones & maps](world.md) — Graph-of-zones model. Fog of war. Lazy generation. Dungeon nesting. Forward compatibility with hex grids.
+- [Encounters & combat](encounters.md) — Goal-not-kills XP. Multiple resolution paths. Combat as a mode of an encounter. Stale-combat cleanup. Initiative.
+- [NPC generation](npcs.md) — Archetypes as role+faction, not species essence. Backstory synthesis with reconciliation. Non-violent resolution as a first-class design principle.
+- [Campaign setup](campaign-setup.md) — The bootstrap phase: player preferences, world generation, pre-history seeding.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,93 @@
+# Architecture
+
+## Consumer
+
+`dm-mcp` is an MCP (Model Context Protocol) toolkit whose **only consumer is an LLM DM agent**. There is no human-DM prose-rendering mode. Every tool returns structured JSON; the DM agent writes narration.
+
+The server sits in the hot path of every player turn:
+
+```
+player → DM agent → dm-mcp tools → DM agent → player
+```
+
+Latency compounds with LLM latency, which is already high. Every design decision in this doc weighs latency as a first-class goal.
+
+## Deployment targets
+
+- **Raspberry Pi** (home-hosted personal play)
+- **Server** (beefier self-host)
+- **Kubernetes pod** (homelab deployment from day one — the user runs K8s at home)
+
+The server is shipped as both a **statically-linked binary** and a **`scratch` container image** (~10–20 MB). No libc, no libssl, no external services. This means:
+
+- **No OpenSSL.** All TLS goes through `rustls`. OpenSSL breaks scratch container builds. If a new dependency silently pulls `native-tls` or `openssl-sys`, that is a build-blocker — swap the dep or select a rustls feature.
+- **One campaign per process.** Multi-campaign hosts spawn one process per campaign. Keeps the connection pool, prepared-statement cache, and content cache simple; avoids cross-campaign state hazards.
+- **SQLite** rather than a sidecar database service. One `campaign.db` file per campaign, bind-mounted or PVC'd in Kubernetes.
+
+## Transport layer
+
+Both **stdio** and **HTTP** are supported from day one. Local DM-agent setups use stdio for lowest latency; Kubernetes deployments use HTTP.
+
+Architecture is a **transport-agnostic dispatch core** with thin transport shells on top:
+
+```
+src/
+  core/
+    dispatch.rs       # fn dispatch(tool, args) -> ToolOutput
+    tools/            # one module per tool; call into domain modules
+  transport/
+    stdio.rs          # MCP framed JSON over stdin/stdout
+    http.rs           # streamable HTTP (or SSE) server + /healthz
+```
+
+Each transport parses the MCP envelope, calls `dispatch`, writes the response back. No business logic in transport.
+
+### Health endpoint
+
+HTTP mode exposes `GET /healthz` which returns 200 when the SQLite database is reachable. Wire it as both a readiness and a liveness probe in Kubernetes.
+
+### MCP SDK
+
+**`rmcp`** (the official Rust SDK from the Model Context Protocol organisation). Chosen because the official SDK tracks protocol changes fastest. The legacy `rust-mcp-sdk` and `rust-mcp-transport` dependencies in the pre-redesign `Cargo.toml` are to be removed.
+
+### CLI shape
+
+```
+dm-mcp stdio     # MCP over stdin/stdout
+dm-mcp http      # MCP over streamable HTTP
+```
+
+## Latency commitments
+
+Non-negotiable defaults chosen for the hot path:
+
+- **SQLite PRAGMAs set at connection open.** `journal_mode=WAL`, `synchronous=NORMAL`, `mmap_size` (64 MB Pi / 256 MB+ server), `cache_size` (32–128 MB), `foreign_keys=ON` (hard-coded; correctness, not tuning).
+- **Prepared statement caching** (`rusqlite::Connection::prepare_cached` or `sqlx`'s equivalent) for every hot query. Parse/plan work runs once.
+- **Batched writes per tool call.** A single call often emits several related events (`encounter.start` + `check.resolve` + `xp.bonus`); wrap them in one transaction. One fsync instead of many — large Pi-SD-card win.
+- **Content tables parsed once at startup** into in-memory structs. Bundled via `include_str!`; tool-call hot path touches no disk for content lookups.
+- **Code-templated event summaries, not LLM-generated.** Every event's `summary` field is produced in Rust from `kind` + `payload`. An LLM call per event write would destroy the budget.
+- **Trim the dependency tree.** Binary size and cold-start matter in containers. Every new crate gets audited for necessity and TLS backend.
+
+## Environment-variable configuration
+
+Every performance knob has a low-latency default and is overridable via `DMMCP_`-prefixed environment variables. A single `Config` struct is loaded once at startup and threaded to the connection opener and the HTTP server.
+
+| Variable                  | Default         | Effect                                                                 |
+|---------------------------|-----------------|------------------------------------------------------------------------|
+| `DMMCP_DB_PATH`           | `./campaign.db` | Path to the SQLite file for this campaign                              |
+| `DMMCP_DB_JOURNAL_MODE`   | `WAL`           | SQLite `journal_mode` PRAGMA                                           |
+| `DMMCP_DB_SYNCHRONOUS`    | `NORMAL`        | SQLite `synchronous` PRAGMA                                            |
+| `DMMCP_DB_MMAP_SIZE`      | `67108864`      | SQLite `mmap_size` PRAGMA, bytes (64 MB)                               |
+| `DMMCP_DB_CACHE_SIZE`     | `-32768`        | SQLite `cache_size` PRAGMA. Negative = kilobytes (32 MB)               |
+| `DMMCP_HTTP_BIND`         | `0.0.0.0`       | HTTP transport bind address                                            |
+| `DMMCP_HTTP_PORT`         | `3000`          | HTTP transport port                                                    |
+| `DMMCP_LOG_LEVEL`         | `info`          | `tracing` log level (`trace`/`debug`/`info`/`warn`/`error`)            |
+| `DMMCP_CONTENT_DIR`       | *(unset)*       | Overrides bundled content with on-disk content directory (dev/custom)  |
+
+`foreign_keys=ON` is not exposed as a knob — correctness, not tuning.
+
+## What's not deployed
+
+- Network calls to external services (the MCP is self-contained).
+- Background workers, schedulers, cron-like workloads (everything is request-response; autonomous NPC behaviour between sessions is explicitly out of scope for MVP).
+- Authentication and multi-tenancy (one campaign per process; security boundary is the container/process boundary).

--- a/docs/campaign-setup.md
+++ b/docs/campaign-setup.md
@@ -1,0 +1,129 @@
+# Campaign setup (bootstrap phase)
+
+Every run of `dm-mcp` begins with a setup phase: a guided dialogue between the DM agent and the player that produces enough information for the world-generator to seed a starting region. Without this phase, every campaign would start in a generic forest with a generic hook. With it, each run feels bespoke.
+
+The setup is a first-class feature, not an afterthought. It's small — a handful of tools and one content file — but it's the hinge on which campaign-to-campaign variety turns.
+
+## Flow
+
+1. **`setup.new_campaign()`** creates an empty database at `DMMCP_DB_PATH`, initialises the schema, and returns the list of setup questions the agent should walk the player through.
+2. **`setup.answer(question_id, answer)`** records each player response as it comes in. Answers live in a lightweight `campaign_setup_answers` table.
+3. **`setup.generate_world()`** uses all answers collected so far to generate the starting zone, a handful of neighbours as stubs, a big-bad archetype instance, initial resident NPCs with cross-zone backstories, and the pre-history events that populate the event log before play begins.
+4. **`setup.mark_ready()`** flips the campaign from "setup" to "running", sets `campaign_hour = 0`, and emits a `campaign.started` event. All subsequent play runs against the generated world.
+
+The setup phase is complete when `mark_ready` fires. From that point the normal tool surface takes over.
+
+## Content: setup questions
+
+```yaml
+# content/campaign/setup_questions.yaml
+
+- id: starting_biome
+  prompt: "What kind of land does the adventure begin in?"
+  options: [forest, plains, mountains, desert, coast, city, dungeon]
+  or_free_text: true
+
+- id: enemy_preference
+  prompt: "What kinds of threats should feature most? (pick as many as you like)"
+  options: [humanoid_raiders, undead, beasts, outsiders, political_intrigue, cults, other]
+  multi: true
+
+- id: tone
+  prompt: "Grim and gritty, balanced, or swashbuckling heroic?"
+  options: [grim, balanced, heroic]
+
+- id: party_size
+  prompt: "Starting alone, with a companion, or in a small party?"
+  options: [solo, one_companion, small_party]
+
+- id: companion_kind
+  prompt: "What sort of companion would you like?"
+  options: [warrior, scholar, rogue, pet_animal, none]
+  conditional: { party_size: [one_companion, small_party] }
+
+- id: big_bad_flavor
+  prompt: "What flavour of primary antagonist should the campaign build toward?"
+  options: [conqueror, corruptor, awakened_ancient, hidden_manipulator, devourer]
+  or_free_text: true
+
+- id: pacing
+  prompt: "Sessions where things are calm and exploratory, or constant pressure?"
+  options: [exploratory, mixed, pressured]
+```
+
+Questions are **ordered** (the agent walks them top to bottom) and can be **conditional** on previous answers (e.g. `companion_kind` only asks if the player chose to have a companion).
+
+`or_free_text: true` means the player may answer outside the option list; the world-generator treats this as a hint rather than a constrained choice.
+
+## Pre-history generation
+
+`setup.generate_world()` does several things in one transaction:
+
+### Starting zone + neighbours
+
+- Picks the starting `zones.biome` from `starting_biome` answer.
+- Creates the starting zone with `kind` appropriate to the biome (`wilderness` for forest/plains/mountains/desert/coast, `settlement` for city, `dungeon` for dungeon).
+- Creates 2–5 neighbour zones as **stubs** (name, biome, kind, size, plus connections back). These are not fully generated — that happens on first visit.
+- Inserts `character_zone_knowledge` rows: `visited` for the starting zone, `rumored` for the neighbours.
+
+### Big bad
+
+- Picks a big-bad archetype seeded by `big_bad_flavor`.
+- Generates the big bad as an NPC via `npc.generate`. They're placed in a zone the player hasn't been to (often far from the starting zone; sometimes in a neighbour for quicker narrative escalation).
+- Synthesizes **deeper backstory** than a normal NPC — 6 to 10 pre-history events — describing how they came to power, past crimes, allies, and lingering threats. These events seed future plot threads.
+
+### Starting NPCs
+
+- Full-generates the starting zone (landmarks, NPCs) using the zone template for the picked biome.
+- Each generated NPC gets 3–5 backstory events, with reconciliation preferring the big bad or each other as participants.
+
+### Pre-history events
+
+All backstory events live in the [event log](history-log.md) with **negative `campaign_hour`** values, representing "before the campaign began." The oldest events (the big bad's origin) might be decades-negative; recent ones (the raid that scared the starting village) might be weeks-negative.
+
+This gives the DM agent a rich backdrop to draw on — every NPC, every landmark, every rumored far-off place has some connective tissue in the log.
+
+### Player character
+
+The player character is created earlier in the setup flow (or is already present, depending on the agent's UX) via a standard `character.create` pathway from the player's chosen class/species/stats. The setup phase doesn't design the player character's mechanics — it just asks about tone and party shape and builds the world around them.
+
+## Schema
+
+Setup adds one small table:
+
+```
+campaign_setup_answers(
+    question_id     TEXT PRIMARY KEY,
+    answer          TEXT,          -- JSON; array for multi-select, string otherwise
+    answered_at     INTEGER        -- real time; campaign_hour is still 0
+)
+```
+
+Plus a single row in a `campaign_state` table tracking whether the campaign is in `setup` or `running`:
+
+```
+campaign_state(
+    id              INTEGER PRIMARY KEY CHECK (id = 1),   -- singleton
+    phase           TEXT NOT NULL,                        -- 'setup' | 'running'
+    started_at      INTEGER?,                             -- real time of mark_ready
+    player_character_id FK?
+)
+```
+
+`CHECK (id = 1)` enforces a single row. Every tool that reads or writes campaign state can trust there's exactly one.
+
+## Tools
+
+| Tool                                              | Effect                                                              |
+|---------------------------------------------------|---------------------------------------------------------------------|
+| `setup.new_campaign()`                            | Create empty DB + schema; return setup questions.                   |
+| `setup.answer(question_id, answer)`               | Record a player response to one question.                           |
+| `setup.get_answers()`                             | Return all answers recorded so far (agent uses for branching).      |
+| `setup.generate_world()`                          | Build starting zone + neighbours + big bad + starting NPCs + pre-history events. |
+| `setup.mark_ready(player_character_id)`           | Flip the campaign to `running`, `campaign_hour = 0`, emit `campaign.started`. |
+
+## Why this matters
+
+The setup phase is cheap to author (one YAML file, a short ordered list of questions) and cheap to run (a few seconds of generator work in one transaction). It transforms the generic "you awake in a forest..." opening into something that reflects the player's tastes and gives the DM agent a world to narrate rather than a blank page.
+
+Combine it with [lazy generation](world.md#lazy-generation) and [the reconciliation pass](npcs.md#reconciliation), and every campaign gets its own identity while the ongoing world continues to build on itself session by session.

--- a/docs/characters.md
+++ b/docs/characters.md
@@ -1,0 +1,230 @@
+# Characters, parties & death
+
+## One table for every living (or dead) thing
+
+The **same `characters` table** backs the player, every companion, every pet, every friendly NPC, every enemy, every bystander. A `role` field and a few nullable columns are the only distinctions between roles. This is the single most load-bearing decision in the data model.
+
+### Why one table
+
+- **Companions come and go.** A mercenary is hired (friendly), then killed (dead). A rescued villager joins the party (companion), later leaves (friendly). An enemy is defeated, then resurrected as a cursed servant. Moving rows between tables when roles change is painful, and every downstream feature (inventory, checks, history, initiative) wants the same shape for all of them.
+- **Pets deserve full statlines.** Players get attached to animal companions and spend potions, spells, and story time growing them into real contributors. A stripped-down pet schema makes "my dog drinks a potion of intellect and is now a full party member" painful to model. Better to give the pet the full schema with low starting stats and empty skill rows that fill in over time.
+- **Recognition and history work identically across roles.** "What does this villager know about this orc?" and "what has my companion witnessed of this zone?" are the same query.
+
+### Role taxonomy
+
+```
+role ∈ { player | companion | friendly | enemy | neutral }
+```
+
+There is exactly one `player` per campaign (solo game). `companion` signals "in the player's party and operates under `issue-an-order` semantics." `friendly`/`enemy`/`neutral` are the social dispositions for NPCs not in the party.
+
+**Roles change via `character.change_role(character_id, new_role, reason)`**, which emits `npc.role_changed` with before/after values and a narrative reason. Side-swaps (enemy becomes ally after learning the truth) are first-class narrative pivots with audit trails.
+
+**No alignment axis.** There is no `good/evil` or `lawful/chaotic` column. Hostility is always situational, not species-essential. See [NPC generation](npcs.md) for how this shapes archetype authoring.
+
+## Schema
+
+```
+characters(
+    id                    PK,
+    name                  TEXT,
+    role                  TEXT,            -- player | companion | friendly | enemy | neutral
+    party_id              FK?,
+
+    -- Ability scores (BASE values; effective = base + active effect modifiers)
+    str_score, dex_score, con_score,
+    int_score, wis_score, cha_score     INTEGER,
+
+    -- Combat numbers
+    hp_current, hp_max, hp_temp          INTEGER,
+    armor_class                          INTEGER,
+    speed_ft                             INTEGER,
+    initiative_bonus                     INTEGER,
+
+    -- Progression (denormalised for read latency)
+    level                                INTEGER,
+    xp_total                             INTEGER,
+    proficiency_bonus                    INTEGER,
+
+    -- Physical
+    size                                 TEXT,          -- tiny..gargantuan
+
+    -- Narrative labels (LLM-interpreted, not mechanised)
+    species                              TEXT,
+    class_or_archetype                   TEXT,
+    ideology                             TEXT,          -- prose for alignment-of-request checks
+    backstory                            TEXT,          -- grows over time
+    plans                                TEXT,          -- current agenda / motivations
+
+    -- Party mechanics
+    loyalty                              INTEGER,       -- 0-100
+
+    -- Lifecycle
+    status                               TEXT,          -- alive | unconscious | dead | missing
+    current_zone_id                      FK?,
+    death_save_successes                 INTEGER,       -- 0-3 while dying
+    death_save_failures                  INTEGER,       -- 0-3 while dying
+
+    created_at, updated_at               INTEGER
+)
+
+parties(
+    id                                   PK,
+    name                                 TEXT?,
+    created_at                           INTEGER
+)
+```
+
+Inventory lives in the [items table](items.md). Skills and proficiencies live in [`character_proficiencies`](checks.md). Temporary effects live in [`effects`](checks.md). Conditions live in [`character_conditions`](checks.md). Limited-use resources (spell slots, etc.) live in [`character_resources`](#resources).
+
+## Key decisions
+
+### Ability scores are base values, never mutated
+
+`str_score` through `cha_score` are the **base** numbers. A potion of giant strength does not rewrite `str_score`; it inserts a row in the `effects` table with `target_key='str_score', modifier=+8`. When the effect expires, the row is marked inactive and the base is untouched.
+
+`resolve_check` reads the **effective** stat: base + sum of active modifiers targeting that key. This answers "what were my stats before the curse" for free, and lets stacking effects compose cleanly.
+
+### `xp_total`, `proficiency_bonus`, `level` are denormalised
+
+All three are theoretically derivable (XP from the event log, proficiency bonus and level from a lookup on XP). They are stored on the character row anyway, and updated **atomically in the same transaction** as the triggering XP event insert.
+
+Reading a character's level on every `resolve_check` should not require aggregating the event log. The denormalisation is a latency decision.
+
+### `class_or_archetype` is a free-text label, not an enum
+
+The MCP does not know the difference between a wizard and a sorcerer. It needs ability scores, proficiencies, HP, and whatever resources the character tracks. Class is a label the DM agent interprets — and keeping it free-text avoids enumerating every variant, homebrew class, and edge case.
+
+### `ideology` is prose, not structured
+
+`ideology` is a single string, typically a sentence, that the DM agent reads to decide whether a given request aligns with or opposes the character's values. See the [ideology-alignment rubric](checks.md#ideology-alignment) for how the agent converts this prose into a check DC modifier.
+
+Structuring ideology (alignment enums, tag lists, value sliders) loses nuance and forces the generator to make reductive choices. Prose is cheap to store and the LLM interprets it well.
+
+### `plans` is prose, updated narratively
+
+`plans` describes the character's current agenda — what they're trying to accomplish. Updated via `character.update_plans(character_id, new_plans, source_event_id)`, which emits `npc.plan_changed`. The agent rewrites plans as narrative develops.
+
+## Parties
+
+Parties are a **grouping only** — no shared stats, no shared inventory, no party-level HP. Characters reference their party via `characters.party_id` and each carries their own inventory, history, and location.
+
+`party_id` is **explicit**, not emergent from co-location. Supports split-the-party scenarios: a captured companion's `current_zone_id` differs from the rest of the party; they remain members until explicitly removed.
+
+Shared gold, shared loot, shared decisions — all narrative conventions the agent handles by choosing which party member's inventory to touch.
+
+## Companions
+
+### Issuing orders is a check, not a control primitive
+
+The player does not directly puppet their companions. Ordering a companion to do something is modelled as a skill check **on the companion**, using:
+
+- **Loyalty** (the numeric `characters.loyalty` column — persistent relationship with the player)
+- **Ideology alignment** (the [rubric-driven modifier](checks.md#ideology-alignment) for this specific request)
+- **Situational modifiers** (distance, stress, conflicting orders)
+
+Telepathy, rangefinding spells, or "talk to animals" are spells that waive proximity or language requirements — they're content data, not a separate subsystem.
+
+### Pets use the full character schema
+
+No `agency` tier, no reduced statline. A dog gets the same columns as a paladin: `str..cha`, HP, AC, skills, resources. A new pet has `int=3, ranks in bite=1`; a heavily-invested pet has grown stats and a wide skill list. The data model doesn't care.
+
+### Loyalty vs ideology
+
+- **Loyalty** is numeric (0–100) and persistent. It captures the character's relationship with the player — earned through shared events (rescued, gifted, fought alongside), lost through betrayal or mistreatment.
+- **Ideology** is prose and per-character. It captures the character's values — stable across time, informs how they interpret specific requests.
+
+The two are **orthogonal**. A fiercely loyal companion can refuse a deeply misaligned order (`loyalty: +4, alignment: -10` → net -6, likely failure). A stranger with favourable alignment can cooperate on first meeting (`loyalty: 0, alignment: +3` → +3, easy success).
+
+## Resources
+
+Limited-use per-rest resources live in a generic table:
+
+```
+character_resources(
+    character_id    FK,
+    name            TEXT,        -- 'slot:1', 'slot:9', 'hit_die', 'mana', 'ki', 'rage_use'
+    current         INTEGER,
+    max             INTEGER,
+    recharge        TEXT,        -- short_rest | long_rest | dawn | never | manual
+    PRIMARY KEY (character_id, name)
+)
+```
+
+Spell slots (`slot:1` through `slot:9`), sorcery points, ki points, rage uses, bardic inspiration, superiority dice, hit dice for short rests — all live here. The agent knows what each namespace means.
+
+`recharge` values are processed by rest tools (`character.short_rest`, `character.long_rest`) which iterate the resource rows and refill matching ones.
+
+## Progression
+
+Experience is awarded via events (see [history log](history-log.md)), never by kills:
+
+- `encounter.goal_completed(encounter_id, character_id, xp)` — fires on goal completion regardless of path. Stealth past the skeletons earns the same XP as fighting them.
+- `xp.bonus(character_id, xp, reason)` — DM-discretionary awards for clever play.
+
+Character XP = sum of these events for the character. The `xp_total` column is kept in sync atomically with the event inserts.
+
+Level is derived from XP via a content-driven lookup table; `proficiency_bonus` is derived from level. Both are denormalised on the character row, and the `character.level_up(character_id)` tool updates all three atomically.
+
+## Death
+
+Three-stage state machine, enforced by the MCP:
+
+### Stage 1 — HP drops to 0
+
+- `apply_condition(mortally_wounded, character_id, …)`
+- `status = 'unconscious'`
+- `hp_current = 0` (never negative)
+- Event emitted so the DM agent knows the character is down
+
+### Stage 2 — Death saves
+
+When the DM calls `roll_death_save(character_id)`:
+
+- d20 rolled
+- `≥ 10` → success (increment `death_save_successes`)
+- `< 10` → failure (increment `death_save_failures`)
+- **Natural 20** → auto-stabilise; `status='alive'`, `hp_current=1`, counters reset
+- **Natural 1** → counts as two failures
+
+Three successes → stabilised (`status='alive'`, `hp_current=1`, counters reset).
+Three failures → `status='dead'`; trigger stage 3.
+
+### Stage 3 — Full death
+
+Because this is a solo RPG, "dead" ends the adventure unless something intervenes. The DM calls `roll_death_event(character_id)`, which rolls on a weighted table in `content/rules/death_events.yaml`:
+
+```yaml
+- weight: 2
+  kind: audience_with_death_god
+  description: "The character finds themselves in the hall of the god of the dead..."
+  outcome_hooks: [bargain, quest, servitude]
+- weight: 5
+  kind: plain_end
+  description: "The character's story ends."
+- weight: 1
+  kind: resurrected_by_ally
+  description: "A companion's grief or a stranger's kindness..."
+  requires: [companion_nearby_or_zone_has_cleric]
+- weight: 1
+  kind: cursed_return
+  description: "Something brings them back, but they're changed."
+  outcome_hooks: [permanent_condition]
+```
+
+The MCP returns the rolled event and its hooks; the DM agent writes the narrative and calls follow-up tools (`bargain` → new quest; `cursed_return` → `apply_condition` with no expiry; etc.). "Three strikes and you're out" stays cleanly enforced by the MCP; "what death means narratively" stays in content and the agent's hands.
+
+## Tools
+
+| Tool                                            | Effect                                                         |
+|-------------------------------------------------|----------------------------------------------------------------|
+| `character.create(...)`                         | Usually invoked via `npc.generate` or campaign setup.          |
+| `character.get(character_id)`                   | Full readout: stats, effective modifiers, conditions, resources|
+| `character.recall(character_id, filters)`       | Events involving this character. See [history](history-log.md). |
+| `character.update_plans(character_id, plans, source_event_id)` | Overwrite `plans`, emit `npc.plan_changed`.      |
+| `character.change_role(character_id, new_role, reason)` | Role swap with audit event.                             |
+| `character.level_up(character_id)`              | Bump level + proficiency_bonus, apply class HP gain.           |
+| `character.short_rest(character_id)`            | Refill resources with `recharge='short_rest'`.                 |
+| `character.long_rest(character_id)`             | Refill resources with `recharge ∈ {short_rest, long_rest, dawn}`. Heal HP. |
+| `roll_death_save(character_id)`                 | Death-save roll; advances the death state machine.             |
+| `roll_death_event(character_id)`                | Fires only after three death-save failures.                    |

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1,0 +1,289 @@
+# Checks, effects & conditions
+
+`resolve_check` is the most frequently-called tool. It must be fast, deterministic, auditable, and flexible enough to cover every kind of d20-inspired check — skill checks, saving throws, attack rolls, ability checks, command/obedience, social interactions.
+
+## The big picture
+
+A check composes four inputs, in order:
+
+1. **The character's base numbers** — ability scores, proficiency bonus, level.
+2. **Proficiency in the specific check's key** — skill, save, weapon, tool, or custom-growth skill like a pet's "bite."
+3. **Active effects** — rows in the `effects` table targeting the relevant key (e.g. *Bless* adds `1d4` to attack rolls and saves; a curse subtracts 2 from a specific stat).
+4. **Active conditions** — rows in `character_conditions` whose mechanical riders (advantage/disadvantage, auto-fail, auto-crit) apply.
+
+Plus caller-supplied **situational modifiers** passed in by the DM agent (ideology alignment, environmental hazards, social context).
+
+## Unified proficiencies table
+
+One table handles 5e-style skills, saving throws, weapon proficiencies, tool proficiencies, **and** pet-style growth skills:
+
+```
+character_proficiencies(
+    character_id    FK,
+    name            TEXT,        -- 'stealth', 'save:str', 'longsword', 'thieves-tools', 'bite'
+    proficient      BOOL,
+    expertise       BOOL,        -- rogue expertise: doubles proficiency bonus
+    ranks           INTEGER,     -- flat additive; used for pet/custom skills
+    PRIMARY KEY (character_id, name)
+)
+```
+
+Naming convention for `name`:
+- **Skills**: the skill name alone — `stealth`, `perception`, `persuasion`.
+- **Saving throws**: prefixed — `save:str`, `save:wis`, etc.
+- **Weapon proficiencies**: the base kind — `longsword`, `longbow`, `unarmed_strike`.
+- **Tool proficiencies**: the tool identifier — `thieves-tools`, `smith-tools`.
+- **Custom / pet skills**: any string the content authors like — `bite`, `intimidating-howl`, `enchanted-resonance`.
+
+A rogue with expertise in Stealth: `(stealth, proficient=1, expertise=1, ranks=0)`.
+A starting dog: `(bite, proficient=0, expertise=0, ranks=1)`.
+A fighter's weapon training: `(longsword, proficient=1, expertise=0, ranks=0)`.
+
+Same query path for every check.
+
+## Effects
+
+Temporary numerical modifiers. **Never mutate base stats.**
+
+```
+effects(
+    id                       PK,
+    target_character_id      FK,
+    source                   TEXT,         -- 'potion:giant-strength', 'curse:rotspeak', 'spell:bless'
+    target_kind              TEXT,         -- ability | ac | speed | hp_max | attack | damage | skill | save
+    target_key               TEXT,         -- 'str_score', 'armor_class', 'stealth', 'save:con'
+    modifier                 INTEGER,      -- signed; negative for debuffs
+    dice_expr                TEXT?,        -- e.g. '1d4' for Bless; rolled per check
+    start_event_id           FK,
+    expires_at_hour          INTEGER?,     -- world-time expiry
+    expires_after_rounds     INTEGER?,     -- combat-round expiry
+    expires_on_dispel        BOOL,
+    active                   BOOL
+)
+```
+
+Index: `effects(target_character_id, active)` — every `resolve_check` reads this.
+
+### Effective-value semantics
+
+```
+effective_str = str_score
+              + SUM(effects.modifier
+                    WHERE target_character_id = me
+                      AND active = 1
+                      AND target_key = 'str_score')
+```
+
+The **base** `str_score` column never changes when a potion is drunk. The effect row is inserted; when the duration ticks down or is dispelled, the row is marked `active = 0` and the base is untouched. This makes "what were my stats before the curse" a free query and lets stacking effects compose.
+
+### `target_kind` alongside `target_key`
+
+`target_kind` is coarse (`ability`, `ac`, `speed`, `skill`, `save`, etc.); `target_key` is specific (`str_score`, `stealth`, `save:con`). Having both lets code branch cheaply ("all ability-score effects on this character") without wildcard string matching.
+
+### `dice_expr` for rolled bonuses
+
+Most effects are flat integers. Some add a rolled die per check — *Bless* famously adds `1d4` to attack rolls and saving throws. The `dice_expr` column captures that; `resolve_check` rolls them as part of the check and records each roll in `payload.rolls`.
+
+## Conditions
+
+Named states (blinded, poisoned, paralyzed, exhaustion, encumbered, mortally_wounded) with **mechanical riders** that aren't pure numerical modifiers.
+
+```
+character_conditions(
+    id                       PK,
+    character_id             FK,
+    condition                TEXT,         -- named: 'blinded', 'charmed', 'poisoned', 'exhaustion', ...
+    severity                 INTEGER,      -- 1 for binary conditions; 1-6 for exhaustion
+    source_event_id          FK,
+    expires_at_hour          INTEGER?,
+    expires_after_rounds     INTEGER?,
+    remove_on_save           TEXT?,        -- e.g. 'save:con:dc15' — retried per round
+    active                   BOOL
+)
+```
+
+### Conditions are separate from effects
+
+They overlap — both apply to a character, both have a source and an expiry. The difference is **shape of consequence**:
+
+- Effects produce *numerical modifiers* that add into a check's total.
+- Conditions produce *rule-level changes* — "disadvantage on attacks," "auto-fail STR saves," "speed penalty," "can't take actions."
+
+Trying to express "paralyzed auto-fails STR and DEX saves" as a numerical effect ends in edge cases. Better to keep conditions as named states and have their mechanical consequences defined in content.
+
+### Mechanical riders live in content, not code
+
+`content/rules/conditions.yaml`:
+
+```yaml
+blinded:
+  self:
+    attack_rolls: disadvantage
+    sight_checks: auto_fail
+  against:
+    attack_rolls: advantage
+
+paralyzed:
+  self:
+    can_move: false
+    can_act: false
+    auto_fail: [save:str, save:dex]
+  against:
+    attack_rolls: advantage
+    auto_crit_if_melee_within_5ft: true
+
+encumbered:
+  self:
+    speed_penalty: -10
+
+mortally_wounded:
+  self:
+    can_act: false
+    hp_floor: 0
+```
+
+The MCP is opinionated about *what these conditions mean* — but the meaning is data, not code. A homebrew profile can override riders without a code change.
+
+### Condition composition
+
+Multiple active conditions compose. Per standard d20 rules, multiple sources of disadvantage still count as a single disadvantage (not double-disadvantage). `resolve_check` walks active conditions and deduplicates rider flags.
+
+## The check flow
+
+```
+resolve_check(character_id, check_spec):
+  char   = SELECT characters WHERE id = character_id
+  effs   = SELECT * FROM effects WHERE target_character_id = ? AND active = 1
+  conds  = SELECT * FROM character_conditions WHERE character_id = ? AND active = 1
+  prof   = SELECT * FROM character_proficiencies
+             WHERE character_id = ? AND name = check_spec.key
+
+  # 1. Ability modifier (effective, not base)
+  effective_score = char[check_spec.ability] + sum(effs where target_key = ability)
+  ability_mod     = (effective_score - 10) / 2    # floor
+
+  # 2. Proficiency contribution
+  prof_contrib  = char.proficiency_bonus * (1 + prof.expertise) * prof.proficient + prof.ranks
+
+  # 3. Effect contributions for this key
+  effect_flat   = sum(effs where target_key matches check_spec.key)
+  effect_dice   = roll_dice_expressions(effs where target_key matches AND dice_expr != NULL)
+
+  # 4. Condition riders
+  rider_flags   = compose_conditions(conds, check_spec.kind)  # adv, dis, auto_fail, ...
+  if rider_flags.auto_fail: emit failure directly; skip the roll
+
+  # 5. Situational modifiers from caller
+  caller_mods   = check_spec.modifiers  # [{ kind, value, reason }, ...]
+
+  # 6. Roll
+  rolls = roll_d20(advantage = rider_flags.advantage,
+                   disadvantage = rider_flags.disadvantage)
+  total = pick_d20(rolls, rider_flags)
+        + ability_mod + prof_contrib + effect_flat + effect_dice
+        + sum(caller_mods.value)
+
+  # 7. Compare to DC
+  success = total >= check_spec.dc
+  crit    = rolls.contains(20)  # for attack rolls; configurable
+  fumble  = rolls.contains(1)
+
+  # 8. Emit event and return
+  emit event kind='check.resolve', payload={dc, total, rolls, breakdown, caller_mods, ...}
+  return { total, success, crit, fumble, rolls, breakdown, event_id }
+```
+
+The full breakdown is returned to the caller and logged in the event's payload for audit.
+
+## Check request shape
+
+```json
+{
+  "character_id": 42,
+  "kind": "skill_check",
+  "skill": "persuasion",
+  "ability": "cha",
+  "target_character_id": 87,
+  "dc": 15,
+  "modifiers": [
+    {
+      "kind": "ideology_alignment",
+      "value": -6,
+      "reason": "cultist's demon-sacrifice goal vs. request to release captive"
+    },
+    {
+      "kind": "hostile_trigger",
+      "value": -3,
+      "reason": "encountered near a ritual site"
+    },
+    {
+      "kind": "situational",
+      "value": +2,
+      "reason": "player produced a forged cult sigil"
+    }
+  ]
+}
+```
+
+### Named modifier kinds
+
+The DM agent passes modifiers through a free `kind` string so the audit event captures intent:
+
+| Kind                 | Typical use                                                           |
+|----------------------|-----------------------------------------------------------------------|
+| `ideology_alignment` | Ideology-rubric-driven modifier for social checks                     |
+| `hostile_trigger`    | Archetype context that pre-biases toward hostility                    |
+| `loyalty`            | Companion-obedience: loyalty-score-to-modifier translation            |
+| `situational`        | Catch-all for environmental, narrative, or improvisational modifiers  |
+| `cover`              | Combat cover (half/three-quarters/full)                               |
+| `flanking`           | Positional tactical modifier                                          |
+
+Every modifier lands in the check event's `payload.modifiers` so later queries ("why did Kira fail that roll?") can cite exact contributors.
+
+## Ideology alignment
+
+Locked rubric lives in content:
+
+```yaml
+# content/rules/ideology_alignment.yaml
+very_aligned:    +3      # the ask actively furthers their goals
+aligned:         +1      # compatible with their worldview
+neutral:          0      # neither helps nor hurts their agenda
+misaligned:      -3      # contradicts a held value
+very_misaligned: -6      # directly opposes a core goal
+hostile_core:   -10      # asks them to betray their deepest commitment
+```
+
+The DM agent reads the target's `ideology` (prose) and `plans` (prose), interprets the player's specific request, picks a tier, and passes the modifier. The rubric keeps magnitudes consistent across sessions.
+
+### Composition
+
+**Allies and companions:**
+```
+total = base + ability_mod + prof_bonus + ranks
+      + loyalty_bonus                    # persistent relationship
+      + ideology_alignment               # this specific ask
+      + situational
+```
+
+**Strangers and enemies:**
+```
+total = base + ability_mod + prof_bonus + ranks
+      + ideology_alignment
+      + hostile_trigger (if applicable)
+      + situational
+```
+
+Loyalty and ideology-alignment are **orthogonal**. Loyalty captures persistent relationship; ideology captures this specific ask vs. this character's goals. A loyal companion can still refuse a deeply misaligned order; a stranger with favourable alignment can cooperate on first meeting.
+
+## Tools
+
+| Tool                                     | Effect                                                     |
+|------------------------------------------|------------------------------------------------------------|
+| `resolve_check`                          | Primary check tool. Described above.                       |
+| `apply_effect(character_id, source, target_kind, target_key, modifier, dice_expr?, expires_...)` | Add an active effect row; emits `effect.applied`. |
+| `dispel_effect(effect_id, reason)`       | Mark effect inactive; emits `effect.expired`.              |
+| `apply_condition(character_id, condition, severity, expires_..., source_event_id)` | Add condition; emits `condition.applied`. |
+| `remove_condition(condition_id, reason)` | Deactivate; emits `condition.expired`.                     |
+| `tick_rounds(encounter_id, rounds)`      | Decrement round-based expiries for effects and conditions of participants; expire what hits zero. Called by `combat.next_turn`. |
+| `tick_hours(hours)`                      | Decrement hour-based expiries across all characters; expire what hits zero. Called by `world.travel`, `character.short_rest`, `character.long_rest`. |

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,120 @@
+# Content
+
+## Principle: content in code, instances in the database
+
+Everything that defines **what a thing is** — what a longsword does, what an orc raider looks like, how much exhaustion-level-3 hurts — lives in bundled YAML files inside the `content/` directory. Everything that describes **which specific thing** — this particular sword held by that particular orc in that particular zone — lives in the SQLite database.
+
+This split has several consequences, all deliberate:
+
+- **Rebuildable worlds, customisable campaigns.** A user who wants to tweak material modifiers, add a new enchantment, or rewrite the death-event table edits YAML and rebuilds. A user who wants runtime iteration points `DMMCP_CONTENT_DIR` at an on-disk copy.
+- **No content migrations.** The database carries instance data only. Adding a new archetype or rebalancing a weapon does not require schema changes or data migrations — just a content edit.
+- **Self-contained binary.** Content is embedded via `include_str!` at compile time. The `scratch` container carries zero runtime file-system dependencies; no mounting of content volumes in the common case.
+- **Testability.** Content tables are plain data. Unit tests load them in isolation, validate schemas, catch typos, and check invariants (every archetype has at least one `peace_hook` unless `can_parley: false`; every enchantment has a `value_premium_gp`; and so on).
+
+## Directory layout
+
+```
+content/
+  rules/
+    abilities.yaml             # six ability scores and what they govern
+    skills.yaml                # named skills → associated ability
+    conditions.yaml            # conditions + mechanical riders
+    damage_types.yaml          # slashing, piercing, fire, necrotic, etc.
+    encumbrance.yaml           # capacity formula, thresholds
+    death_events.yaml          # rolled when a character fully dies
+    ideology_alignment.yaml    # the +3 to -10 rubric
+    xp_level_table.yaml        # XP → level → proficiency_bonus
+
+  items/
+    bases/
+      weapons.yaml             # longsword, dagger, greataxe, longbow, ...
+      armor.yaml               # leather, mail, plate, shields
+      consumables.yaml         # potions, rations, scrolls
+      general.yaml             # gold, rope, torches, tools
+    materials.yaml             # tier-1 basic → tier-5 exotic; weight, value, damage, durability modifiers
+    enchantments.yaml          # glowing, sharpness, goblinbane, scaling and static
+
+  npcs/
+    archetypes/                # one file per archetype
+      orc_raider.yaml
+      orc_merchant.yaml
+      village_baker.yaml
+      death_cultist.yaml
+      hedge_wizard.yaml
+      forest_wolf.yaml
+      ...
+    name_pools/                # per species/culture
+      orc.yaml
+      human_northern.yaml
+      elf_sylvan.yaml
+      ...
+
+  world/
+    biomes.yaml                # forest, plains, mountains, etc.; encounter-tag pools
+    encounters.yaml            # encounter templates with goals, participants, resolution_paths
+    dungeon_templates.yaml     # procedural dungeon parameters
+    zone_templates/            # per-biome NPC-slot definitions and landmark pools
+      wilderness_forest.yaml
+      settlement_village_small.yaml
+      settlement_city.yaml
+      dungeon.yaml
+
+  campaign/
+    setup_questions.yaml       # bootstrap dialogue
+```
+
+## Authoring rules
+
+### Rules → see related docs
+
+- [Characters, parties & death](characters.md) — for `death_events.yaml` shape
+- [Checks, effects & conditions](checks.md) — for `conditions.yaml` rider syntax and `ideology_alignment.yaml` rubric
+- [Items & inventory](items.md) — for `weapons.yaml`, `materials.yaml`, `enchantments.yaml` shapes
+- [NPC generation](npcs.md) — for archetype YAML shape
+- [World, zones & maps](world.md) — for zone and dungeon templates
+- [Encounters & combat](encounters.md) — for encounter resolution-paths shape
+- [Campaign setup](campaign-setup.md) — for setup-questions shape
+
+### IP-safety rules are hard
+
+Every content file is subject to the [IP & licensing](ip-and-licensing.md) rules. Summary: original text or text derived from openly-licensed sources (5.1 SRD CC-BY-4.0 or ORC-licensed material) only. No copy-paste of WotC product-book text. No "D&D" / "5e" / "Dungeons & Dragons" branding anywhere.
+
+### No alignment axis in archetypes
+
+- No `alignment: evil`, no `good_evil: true`.
+- Hostility is expressed through situation, faction, and `hostile_triggers` — not species nature.
+- Every hostile encounter must have at least one peaceful `resolution_path`, unless all participants are mindless (`can_parley: false`).
+
+See [NPC generation — non-violent resolution](npcs.md#non-violent-resolution-first-class) for the full rule.
+
+## Loading
+
+At startup, the content loader:
+
+1. Walks the embedded or on-disk content directory.
+2. Parses each YAML into typed Rust structs (via `serde`).
+3. Validates internal invariants (all archetype weapon proficiencies reference valid weapon base_kinds; all enchantment `effects` reference valid `target_kind` values; etc.).
+4. Stores everything in a single `Content` struct held in the application's global state.
+5. Exposes indexed accessors (`content.archetype("orc_raider")`, `content.enchantment("sharpness")`, `content.biome("forest")`).
+
+**The loader runs exactly once per process.** Tool-call hot paths never touch disk or parse YAML. Any time a tool says "look up the longsword's base weight," that's an O(1) hash lookup in an in-memory struct.
+
+## Overriding bundled content
+
+Set `DMMCP_CONTENT_DIR=/path/to/content` to load from disk instead of the embedded copy. Two uses:
+
+- **Development iteration.** Edit a YAML, restart the process, see the change — no `cargo build` cycle.
+- **End-user customisation.** A user running the container can mount a custom content directory and the image uses it without rebuilding.
+
+The on-disk directory must have the same layout as the bundled one. If required files are missing, the loader fails fast at startup with a clear error.
+
+## When to change schema vs. content
+
+If you find yourself tempted to add a column to a database table to support a new rule, ask: *can this live in content instead?*
+
+- A new status effect? **Content** (`conditions.yaml`).
+- A new weapon? **Content** (`weapons.yaml`).
+- A new ability score that doesn't exist in d20 systems? Schema change — base stats are on `characters`.
+- A fundamentally new entity type (a "building" that isn't a zone or landmark)? Schema change — new table.
+
+Most additions should be content-only. Schema changes are a smell; think twice.

--- a/docs/encounters.md
+++ b/docs/encounters.md
@@ -1,0 +1,161 @@
+# Encounters & combat
+
+An **encounter** is the narrative container for a situation that takes the player's focus: a bandit ambush, a negotiation with a merchant prince, a descent into a dungeon level, a puzzle room, a pursuit.
+
+Encounters have **goals, not kill quotas**. XP is awarded when the goal is resolved, regardless of how. Combat is one resolution path among several — stealth, negotiation, side-swapping, and clever bypasses all earn the encounter's XP budget.
+
+## Schema
+
+```
+encounters(
+    id                         PK,
+    zone_id                    FK,
+    name                       TEXT,
+    goal                       TEXT,           -- content key or free-text
+    estimated_duration_hours   INTEGER,
+    xp_budget                  INTEGER,        -- authored; baseline award on goal completion
+    status                     TEXT,           -- active | goal_completed | abandoned | failed
+
+    -- Combat state inline; NULL outside combat
+    in_combat                  BOOL,
+    current_round              INTEGER?,
+    turn_index                 INTEGER?,       -- index into initiative-sorted participants
+
+    started_at_hour            INTEGER,
+    ended_at_hour              INTEGER?
+)
+
+encounter_participants(
+    encounter_id               FK,
+    character_id               FK,
+    side                       TEXT,           -- player_side | hostile | neutral | ally
+    initiative                 INTEGER?,       -- rolled at combat start; NULL outside combat
+    has_acted_this_round       BOOL,
+    PRIMARY KEY (encounter_id, character_id)
+)
+```
+
+## Key decisions
+
+### Goal, not participants, drives XP
+
+Encounter XP fires on `encounter.goal_completed`, carrying the full `xp_budget` regardless of whether the player fought, negotiated, snuck past, or redirected the threat. Two corollaries:
+
+- **"Kill XP" does not exist.** No event kind awards XP for defeating a specific enemy. A goblin chief who's part of an encounter contributes to the XP budget authorship; killing them doesn't fire XP on its own.
+- **Bypass is legitimate.** Stealth past the skeletons earns the same XP as fighting them. The encounter's goal — "retrieve the item from the tower" — is what the player is rewarded for.
+
+Paired with discretionary `xp.bonus` awards from the DM for clever play, this keeps player motivation aligned with problem-solving rather than combat grinding.
+
+### Combat is a mode of the encounter, not a separate subsystem
+
+The `in_combat`, `current_round`, and `turn_index` columns live directly on `encounters`. Initiative lives on `encounter_participants`. There are no `combat_encounters` or `combat_participants` tables.
+
+This is deliberate:
+- Same encounter row serves narrative and combat purposes — no join from "in this encounter" to "in this combat."
+- Combat state (initiative, round) is NULL outside combat and doesn't clutter encounters that never enter combat.
+- Transitioning in and out of combat is toggling a flag, not moving rows between tables.
+
+### Combat state is cleaned up automatically
+
+`combat.start(new_encounter_id)` **first** auto-ends any other encounter currently flagged `in_combat=1` (calling `combat.end(other_id, reason='superseded_by_new_combat')`), **then** starts the new combat.
+
+This guards against the DM agent forgetting to call `combat.end` before moving on narratively. Without the auto-cleanup, a random goblin from a fight four hours ago could still be "in combat" when a new fight starts. The event log captures the auto-cleanup so the audit trail is intact.
+
+### Participants outlast combat
+
+`encounter_participants` rows persist after combat ends. That's how goal-XP payout finds who should receive XP (every participant on `player_side` gets the budget divided appropriately), and how recognition queries work ("has this character been in an encounter with that one?").
+
+Combat-only fields (`initiative`, `has_acted_this_round`) are NULL-ed out on `combat.end`; the row itself stays.
+
+## Resolution paths
+
+Every authored encounter declares its resolution paths:
+
+```yaml
+# content/world/encounters/orc_raid.yaml
+orc_raid:
+  participants:
+    - { archetype: orc_raider,   count: "1d4+2" }
+    - { archetype: orc_warchief, count: 1 }
+  goal: "Resolve the conflict between the raiders and the villagers"
+  estimated_duration_hours: 2
+  xp_budget: 300
+  encounter_tags: [hostile, humanoid_raiders, social_possible]
+  resolution_paths:
+    - kind: combat_victory
+      note: "Defeat the raiders"
+    - kind: parley_to_peace
+      note: "Broker peace after discovering the child-enslavement cause, mediate restitution"
+    - kind: side_swap
+      note: "Ally with the orcs against the villagers after learning the truth"
+    - kind: redirection
+      note: "Divert the raiders to a different target"
+    - kind: flight
+      note: "Escape / evacuate villagers without engagement"
+      xp_modifier: 0.5
+```
+
+- The MCP **does not enforce** which path the player took. The DM agent calls `encounter.complete(encounter_id, path, xp_modifier?)` when the goal is reached; the event captures which path was taken in its payload.
+- `xp_modifier` on a resolution path (default 1.0) multiplies the authored `xp_budget` for that path. A pure flight that abandons the villagers yields half XP; a clever redirection might yield full XP plus a discretionary bonus for cleverness.
+- **Every hostile encounter must have at least one peaceful resolution path.** This is a content-authoring rule — see [IP & licensing](ip-and-licensing.md) and [NPC generation](npcs.md#non-violent-resolution). The exception is truly mindless participants (animated skeletons, undirected undead) for which combat or avoidance are the only options.
+
+## Combat flow
+
+### Starting combat
+
+`combat.start(encounter_id)`:
+
+1. Auto-end any other in-combat encounter (see above).
+2. `encounters.in_combat = 1`.
+3. Roll initiative for each `encounter_participants` row (d20 + character's `initiative_bonus`).
+4. Sort participants by initiative descending; `turn_index = 0`; `current_round = 1`.
+5. Reset `has_acted_this_round = 0` for everyone.
+6. Emit `combat.start` event.
+
+### Advancing turns
+
+`combat.next_turn(encounter_id)`:
+
+1. Mark the current participant's `has_acted_this_round = 1`.
+2. Increment `turn_index`.
+3. **If the index wraps past the last participant:**
+   - `current_round += 1`.
+   - `has_acted_this_round` reset to 0 for all participants.
+   - Walk `effects` and `character_conditions` for this encounter's participants where `expires_after_rounds IS NOT NULL`; decrement by 1; mark any that hit 0 as inactive; emit expiry events.
+4. Emit `combat.next_turn` with the new current participant.
+
+All round-based bookkeeping happens here; nothing else ticks combat-round timers.
+
+### Ending combat
+
+`combat.end(encounter_id, reason?)`:
+
+1. `encounters.in_combat = 0`; `current_round = NULL`; `turn_index = NULL`.
+2. `encounter_participants.initiative = NULL`; `has_acted_this_round = 0` for all.
+3. Emit `combat.end` or `combat.auto_ended` (depending on `reason`).
+
+Combat ends explicitly via the DM calling it, or implicitly via `combat.start` on a new encounter (the auto-cleanup path).
+
+## Per-turn action economy — deferred
+
+The real 5e-style action economy (action, bonus action, reaction, move speed per turn) is **not enforced** by the MCP in MVP. The DM agent narrates action usage within a turn; `combat.next_turn` is the only round-level event the MCP tracks.
+
+If enforcement becomes valuable later, it can be added as a `turn_actions_used` JSON column on `encounter_participants` without other schema impact. Deferring avoids forcing every combat tool to thread action-type checks through the dispatch layer for minimal MVP benefit.
+
+## Tools
+
+| Tool                                                     | Effect                                                                |
+|----------------------------------------------------------|-----------------------------------------------------------------------|
+| `encounter.create(zone_id, goal, participants, xp_budget, estimated_duration_hours, resolution_paths)` | Create an encounter; usually called by the zone/encounter generator. |
+| `encounter.get(encounter_id)`                            | Full state: participants, status, combat mode, round, turn.           |
+| `encounter.complete(encounter_id, path, xp_modifier?)`   | Mark status `goal_completed`; fire XP to `player_side` participants. Advance world clock by `estimated_duration_hours` or a DM-provided delta. |
+| `encounter.abandon(encounter_id, reason)`                | Mark status `abandoned`; no XP; advance world clock by elapsed.       |
+| `encounter.fail(encounter_id, reason)`                   | Mark status `failed`; no XP; advance world clock by elapsed.          |
+| `encounter.add_participant(encounter_id, character_id, side)` | Add a character (reinforcements, bystander entering the fray). |
+| `encounter.remove_participant(encounter_id, character_id, reason)` | Remove (fled, captured, unconscious out of fight). |
+| `combat.start(encounter_id)`                             | Enter combat mode. Auto-ends any other in-combat encounter.           |
+| `combat.next_turn(encounter_id)`                         | Advance initiative pointer; tick round timers at round boundary.      |
+| `combat.end(encounter_id, reason?)`                      | Exit combat mode.                                                     |
+| `combat.apply_damage(character_id, amount, damage_type, source?)` | Reduce `hp_current`; trigger [death flow](characters.md#death) if HP hits 0. |
+| `combat.apply_healing(character_id, amount, source?)`    | Increase `hp_current` up to `hp_max`; if `mortally_wounded`, clear condition and reset death-save counters. |
+| `encounter.award_bonus_xp(character_id, xp, reason)`     | DM-discretionary `xp.bonus` event.                                    |

--- a/docs/history-log.md
+++ b/docs/history-log.md
@@ -1,0 +1,145 @@
+# History & event log
+
+The event log is the **connective tissue** of the world. It powers:
+
+- **NPC backstory generation** — sampling prior events to give newly-generated NPCs 3–5 cross-references to other entities.
+- **Recognition scenes** — "the villagers recognise this orc because it raided them" is a join over the log.
+- **Player recall** — "what did I do in the tower last session" is a character-scoped log query.
+- **XP arithmetic** — character XP is the sum of `xp.*` events for that character.
+- **Effect / condition lifecycles** — every effect links back to the event that applied it; every expiry is an event.
+- **Audit trail** — append-only, so the DM agent can always trust what it reads.
+
+## Schema
+
+One polymorphic event table plus two junction tables for indexed "events involving X" queries:
+
+```
+events(
+    id              PK,
+    kind            TEXT,       -- dotted taxonomy: combat.hit, xp.goal, effect.applied, ...
+    campaign_hour   INTEGER,    -- cumulative in-game hours since campaign start (may be negative)
+    combat_round    INTEGER?,   -- set only for events inside combat
+    zone_id         FK?,        -- null for global / cross-zone events
+    encounter_id    FK?,        -- null outside encounters
+    parent_id       FK?,        -- ties sub-events to their parent (a resolved check → individual rolls)
+    summary         TEXT,       -- one-line prose the LLM reads directly
+    payload         TEXT        -- JSON; schema varies by kind
+)
+
+event_participants(
+    event_id        FK,
+    character_id    FK,
+    role            TEXT,       -- actor | target | witness | beneficiary
+    PRIMARY KEY (event_id, character_id, role)
+)
+
+event_items(
+    event_id        FK,
+    item_id         FK,
+    role            TEXT,       -- same roles as above; items can be 'stolen', 'given', 'destroyed', etc.
+    PRIMARY KEY (event_id, item_id, role)
+)
+```
+
+## Design decisions
+
+### Polymorphic `events` table, not per-kind satellite tables
+
+A single `events` table with a JSON `payload` column is much easier to extend than a family of satellite tables. New event kinds only need a new string for `kind`; no migrations.
+
+The cost of JSON payload is that type-specific fields aren't trivially queryable. That's fine for this project — the **cross-entity queries** (recognition, backstory, recall) only need entity filters, and those go through `event_participants`/`event_items` junction tables which are indexed.
+
+### `kind` is a dotted taxonomy, not an enum
+
+`combat.hit`, `combat.miss`, `combat.death`, `xp.goal`, `xp.bonus`, `effect.applied`, `effect.expired`, `stat.change`, `inventory.transfer`, `location.move`, `social.persuade`, `social.bargain`, `social.refusal`, `discovery.secret`, `discovery.landmark`, `encounter.start`, `encounter.goal_completed`, `encounter.abandoned`, `combat.start`, `combat.next_turn`, `combat.end`, `combat.auto_ended`, `history.backstory`, `history.relationship.family`, `npc.role_changed`, `npc.plan_changed`, `meta.retraction`, …
+
+Filtering is broad (`kind LIKE 'combat.%'`) or exact (`kind = 'combat.hit'`). Adding a new kind is a string; no migration, no enum edit.
+
+### `summary` is code-templated, not LLM-generated
+
+The `summary` column is mandatory prose such as *"Kira hit the orc for 7 damage with a rusted axe."* It is produced in Rust from `kind` + `payload` at event insert time.
+
+**Do not use an LLM call to generate summaries.** An LLM call per event would destroy the latency budget, and summaries are formulaic enough that a template renderer produces equivalent-quality text.
+
+### `parent_id` gives event hierarchies
+
+A `check.resolve` event is the parent of the individual dice-roll events that produced it (if those are emitted as separate events at all — see below). An encounter's `encounter.start` … `encounter.goal_completed` pair wraps many child events.
+
+This lets the agent request "the whole check, with rolls" or "everything that happened in encounter 91" as a tree query, and lets coarse summaries cite fine-grained detail on demand.
+
+### Rolls live in the parent check's payload, not as child events
+
+Default: a `check.resolve` event with `payload.rolls = [{d20: 14, mods: [{...}]}]` captures everything needed for audit without inflating the event table. Child events are reserved for sub-events with their own narrative weight (a critical hit's extra damage roll, a triggered saving throw).
+
+This keeps event volume manageable without losing fidelity.
+
+### Append-only; retractions are new events
+
+Never update or delete event rows. A correction is a new event with `kind='meta.retraction'` and `parent_id=<bad>`. This makes the log trustworthy — the agent can always believe what it reads — and keeps stat/effect reconstructions deterministic.
+
+### Indexes
+
+```
+event_participants(character_id, event_id)     # "events involving X" — the hottest path
+events(zone_id, campaign_hour DESC)            # "recent events in this zone"
+events(encounter_id)                           # assembling an encounter's full history
+events(parent_id)                              # walking event trees
+events(kind, campaign_hour DESC)               # broad kind-filtered queries
+```
+
+## Two-tier time model
+
+```
+events.campaign_hour    INTEGER NOT NULL    -- cumulative in-game hours
+events.combat_round     INTEGER NULL        -- set only for events inside combat
+```
+
+### World time
+
+`campaign_hour` is an integer: cumulative hours since campaign start.
+
+- **Campaign start is `campaign_hour = 0`**, the moment `setup.mark_ready` fires.
+- **Negative values = pre-campaign fictional history** — used by NPC backstory synthesis to place events "in the past, before the campaign began." Easy to filter out of "recent events" queries.
+- Day/night and calendar are derivable: `campaign_hour % 24` gives hour-of-day, integer division by 24 gives day number, and so on. No separate calendar table.
+- Hour is the minimum world-time granularity. Resting advances the clock in 8-hour jumps; travel in multi-hour segments; encounters in authored-duration blocks.
+
+### Combat time
+
+`combat_round` is nested inside combat. A round is six in-game seconds. While `encounters.in_combat = true`, every event emitted carries `combat_round = encounters.current_round`; events outside combat have `combat_round = NULL`.
+
+**The two clocks do not reconcile arithmetically.** A 20-round brawl does not cost 120 real-world seconds of world time — the encounter's world-time cost is whatever it was authored for. Combat rounds exist solely for in-combat effect/condition expiry bookkeeping and initiative tracking.
+
+### Encounter duration
+
+Encounters carry an `estimated_duration_hours` field set at generation. When an encounter closes (`encounter.goal_completed`, `encounter.abandoned`, etc.), the world clock advances by that (or a DM-adjusted actual delta, logged on the closing event). Example: a 6-hour tower entered at dawn (`campaign_hour=1248`) closes at `campaign_hour=1254` with plenty of daylight left for another event.
+
+## Example event chain
+
+A bribe that fails because the guard has strong ideology:
+
+```
+events:
+  id=847, kind='social.bargain', campaign_hour=1203, encounter_id=91, parent=NULL
+          summary='Kira offered the guard 10g to let her pass'
+          payload={"offer":10, "currency":"gold"}
+  id=848, kind='check.resolve', parent=847
+          summary='Kira persuasion check failed (14 vs DC 18)'
+          payload={"skill":"persuasion","dc":18,"total":14,"rolls":[{"d20":8}],
+                   "modifiers":[{"kind":"ideology_alignment","value":-2,
+                                 "reason":"guard's duty vs request to shirk it"}]}
+  id=849, kind='social.refusal', parent=847
+          summary='The guard refused and called for backup'
+
+event_participants:
+  (847, Kira, actor)    (847, guard, target)
+  (848, Kira, actor)
+  (849, guard, actor)   (849, Kira, target)
+```
+
+The full breakdown — DC, rolls, modifier rationale — is captured in the payload. The three chained summaries make the story readable without the agent ever touching JSON.
+
+## Scope
+
+**Single table, indexed.** Per-fight partitioning was considered and rejected: the cross-entity queries that matter (recognition, backstory sampling, recall) would become N+1 `UNION ALL` joins across per-fight tables, which fight the query planner and are slower than one indexed table.
+
+**If event volume ever becomes a real problem**, split by event *hotness*, not by encounter boundary: keep the lean `events` header table hot and offload wide combat-roll detail to a secondary `event_detail_rolls` table. Don't add this pre-emptively.

--- a/docs/ip-and-licensing.md
+++ b/docs/ip-and-licensing.md
@@ -1,0 +1,81 @@
+# IP & licensing
+
+This project borrows mechanical shape from decades of tabletop-RPG design — six ability scores, advantage/disadvantage, d20 resolution, hit points, armor class. That's fine: **game mechanics and formulas are not copyrightable**. What *is* protected is the specific text of published products and the distinctive proper nouns, and this project must not infringe on either.
+
+The project is **released free**. Profit-off-someone-else's-IP is not the risk; cease-and-desist demands and takedown requests are. The rules below are written to keep the project defensible.
+
+## Hard rules
+
+### Content sources
+
+**OK to draw from:**
+
+- **5.1 SRD (CC-BY-4.0).** Wizards of the Coast released the 5.1 System Reference Document under Creative Commons Attribution in 2023. Mechanical content (ability scores, proficiency bonus, advantage/disadvantage, standard conditions, damage types, saving throws, most spells in the SRD, most monsters in the SRD) is reusable with attribution.
+- **ORC-licensed material.** The Open RPG Creative License (Paizo, Kobold Press, and other contributors) covers a growing library of mechanical content, monsters, and items.
+- **Public-domain mythology, folklore, and history.** Dragons, elves, wolves, graveyards, medieval taverns — all fine.
+- **Original writing.** Anything you write yourself.
+
+**Not OK to copy from:**
+
+- **Any WotC product book** other than the 5.1 SRD. This includes the Player's Handbook, Dungeon Master's Guide, Monster Manual, Xanathar's Guide, Tasha's Cauldron, Fizban's Treasury, Mordenkainen's Monsters of the Multiverse, and every campaign setting book. WotC owns that text.
+- **Even mechanically-identical spells or items** if the text is lifted from a non-SRD book. Stat blocks, flavor paragraphs, item descriptions — all copyrighted.
+- **Distinctive WotC proper nouns.** Mind Flayer, Beholder, Githyanki, Githzerai, Displacer Beast, Umber Hulk, Carrion Crawler, Slaad, Kuo-toa, Modron, Tarrasque (outside the SRD), Yuan-ti (outside the SRD), named Forgotten Realms or Greyhawk deities, specific named NPCs. When in doubt, assume it's a WotC-specific name and pick an alternative.
+
+### Branding
+
+- **Never use** "D&D", "Dungeons & Dragons", "5e", "5th Edition", or any WotC product name in the README, documentation, code comments, user-facing strings, error messages, container image labels, or commit messages.
+- **Use instead** "d20-inspired", "core rules profile", or "d20-style".
+- The name `dm-mcp` is generic enough ("Dungeon Master" is pre-WotC English; "MCP" is the Model Context Protocol).
+
+### Attribution for SRD-derived content
+
+The CC-BY-4.0 license requires attribution. When content files include something directly derived from the SRD, cite it in a comment so the attribution is clear:
+
+```yaml
+# content/items/bases/weapons.yaml
+longsword:
+  # Derived from SRD 5.1 (CC-BY-4.0) — "Longsword" weapon entry
+  damage: 1d8
+  damage_type: slashing
+  weight_lb: 3
+  base_value_gp: 15
+```
+
+A single `ATTRIBUTIONS.md` in the repo root (or at the content directory root) aggregates per-file attributions for easy compliance review.
+
+## Why this is enough
+
+Rules and mechanics aren't copyrightable. A game with six ability scores called STR/DEX/CON/INT/WIS/CHA, a proficiency bonus that scales with level, and attack rolls against armor class is mechanically indistinguishable from 5e — and fully legitimate. What WotC owns is the *expression* (the words in their books) and the *marks* (their brand, specific product names, distinctive creature names).
+
+Staying firmly in SRD/ORC/original territory avoids the expression side. Dropping WotC branding avoids the marks side. The result is a project that can run solo RPG campaigns in a 5e-*shaped* system without being a 5e *product*.
+
+## Authoring workflow
+
+When writing or reviewing a content file:
+
+1. **Did you copy any prose from a WotC book?** If yes, rewrite in your own words — or delete it and use a mechanical-only entry with an original description.
+2. **Does it use a WotC-proprietary name?** Check against common trademark lists (Mind Flayer, Beholder, etc.). Swap for a SRD-available equivalent or invent a name.
+3. **If it's SRD-derived, is the attribution cited?** Add the comment.
+4. **Does the README / docs / code mention "D&D" or "5e"?** Remove.
+
+A release checklist lives in `ATTRIBUTIONS.md` (to be written when content authoring begins). Periodic scans for WotC-proprietary terms across `content/` are part of release prep.
+
+## Examples
+
+**OK:**
+
+> "A longsword — versatile, reliable, good in most hands. 1d8 slashing damage, 3 lbs, 15 gp."
+
+**Not OK** (lifted verbatim from a WotC source):
+
+> "This sword shows signs of careful use, its blade darkened by...".
+
+**OK (original flavor):**
+
+> "A tall, gaunt humanoid with webbed hands and ink-black eyes. Speaks in whispers that seem to come from all around."
+
+**Not OK** (this creature is a WotC proprietary name and should not appear by name even if stat-described correctly):
+
+> "A Mind Flayer — a humanoid aberration that feeds on intelligent minds..."
+
+When in doubt: write it yourself, or cite the SRD.

--- a/docs/items.md
+++ b/docs/items.md
@@ -1,0 +1,242 @@
+# Items & inventory
+
+## Model in one sentence
+
+Every physical thing in the world is a row in **one** `items` table. Its base properties (damage, weight, value) come from bundled content tables keyed on `base_kind`. Per-instance variation (material, enchantments, damage, charges, quantity, location) lives on the row.
+
+## Schema
+
+```
+items(
+    id                     PK,
+    base_kind              TEXT,           -- content lookup key: 'longsword', 'potion-of-healing', 'gold'
+    name                   TEXT?,          -- optional custom name: 'Frostbane'
+    material               TEXT?,          -- 'steel', 'glass', 'wood'; null for non-material items
+    material_tier          INTEGER?,       -- +1 basic ... +5 exotic
+    quality                TEXT?,          -- 'pristine', 'worn', 'broken'
+    quantity               INTEGER,        -- stackables; 1 for unique items
+    charges                INTEGER?,       -- e.g. wand charges; null for non-charge items
+    charges_max            INTEGER?,
+
+    -- Exactly one of the three location FKs is non-null
+    holder_character_id    FK?,            -- in a character's inventory
+    container_item_id      FK?,            -- nested inside another item (chest, pouch)
+    zone_location_id       FK?,            -- on the ground in a zone
+
+    equipped_slot          TEXT?,          -- 'main-hand' | 'off-hand' | 'head' | 'chest' | ...
+
+    created_at_event_id    FK?,
+    updated_at             INTEGER
+)
+
+item_enchantments(
+    id                     PK,
+    item_id                FK,
+    enchantment_kind       TEXT,           -- content key: 'glowing', 'sharpness', 'goblinbane'
+    tier                   INTEGER?,       -- scaling enchantments: +1 / +2 / +3
+    charges                INTEGER?,       -- depletable enchantments
+    notes                  TEXT?
+)
+```
+
+Location mutex is enforced by `CHECK` constraint:
+
+```sql
+CHECK (
+    ((holder_character_id IS NOT NULL) +
+     (container_item_id IS NOT NULL) +
+     (zone_location_id IS NOT NULL)) = 1
+)
+```
+
+An item is always in exactly one place: a character's inventory, nested in another item (chest, pouch, bag of holding), or loose in a zone. `inventory_transfer` tools update the three location columns atomically.
+
+## Key decisions
+
+### Single `items` table, not a type catalog
+
+There is no `item_types` table in the database. The content directory defines every `base_kind` in bundled YAML:
+
+```yaml
+# content/items/bases/weapons.yaml
+longsword:
+  damage: 1d8
+  damage_type: slashing
+  weight_lb: 3
+  base_value_gp: 15
+  properties: [versatile]
+  slot: main-hand
+
+# content/items/bases/consumables.yaml
+potion-of-healing:
+  weight_lb: 0.5
+  base_value_gp: 50
+  stackable: true
+  charges_max: 1
+
+# content/items/bases/general.yaml
+gold:
+  weight_lb: 0.02
+  base_value_gp: 1
+  stackable: true
+```
+
+Storing every possible longsword variant (steel longsword, glass longsword, iron longsword of sharpness, …) as a row in an `item_types` table would explode combinatorially and fight the content-is-code principle.
+
+### Material as a column, enchantments as a satellite table
+
+A weapon or armor instance has **exactly one material** (steel, wood, bone) — one column does the job. An instance has **zero or more enchantments** — a junction table lets enchantments stack and carry their own per-enchantment state (charges, tier).
+
+This is the correct factoring for the common case: "a glass longsword of goblin-slaying" is `{base_kind: longsword, material: glass, material_tier: 1}` plus one row in `item_enchantments`.
+
+### Currency is just items
+
+No dedicated `gold`/`silver`/`copper` columns on characters. A character's gold is one row:
+
+```
+items { base_kind='gold', quantity=123, holder_character_id=player.id }
+```
+
+Transfer, theft, barter, and containerised storage (gold in a pouch in a chest) all go through the same code paths as any other item.
+
+### Stackables via `quantity`
+
+50 arrows is one row with `quantity=50`, not 50 rows. The item's content base kind declares `stackable: true` — the insert/merge logic consolidates matching items on pickup.
+
+Two items are "matching" for stacking if they share `base_kind`, `material`, `material_tier`, `quality`, and have no distinct enchantments. An enchanted arrow does not stack with a mundane one of the same base kind.
+
+### Base stats come from content, not the DB
+
+The database answers "what is this item?" with a content key (`base_kind`). The rest of the answer — damage dice, weight, base value, slot, properties — comes from the in-memory content tables.
+
+This keeps the database small, keeps content editable without migrations, and means every item inherits updates to its base kind at reload time.
+
+## Composed stats
+
+When a tool needs the **effective stats** of an item — for damage rolls, encumbrance calculations, shop pricing — it composes four inputs:
+
+```
+effective_damage     = base.damage                  -- e.g. 1d8
+                     + sum(enchantment.damage_bonus_if_matches_target)
+
+effective_weight     = base.weight_lb
+                     * material.weight_multiplier
+                     * quantity
+                     + sum(enchantment.weight_delta)
+
+effective_value_gp   = base.value_gp
+                     * material.value_multiplier
+                     * quality_multiplier
+                     + sum(enchantment.value_premium)
+
+effective_name       = name
+                     ?? format(base.name, material, enchantment summaries)
+```
+
+Material and quality multipliers come from content:
+
+```yaml
+# content/items/materials.yaml
+steel:       { tier: 1, weight_mult: 1.0, value_mult: 1.0, damage_bonus: +0, durability: 1.0 }
+iron:        { tier: 1, weight_mult: 1.1, value_mult: 0.8, damage_bonus: +0, durability: 0.9 }
+glass:       { tier: 3, weight_mult: 0.5, value_mult: 3.0, damage_bonus: +1, durability: 0.3 }
+dragonbone:  { tier: 5, weight_mult: 0.6, value_mult: 8.0, damage_bonus: +3, durability: 1.5 }
+```
+
+Quality multipliers for `{pristine: 1.2, worn: 0.9, broken: 0.1}` or similar.
+
+## Enchantments
+
+```yaml
+# content/items/enchantments.yaml
+glowing:
+  kind: utility
+  value_premium_gp: 50
+  weight_delta: 0
+  effects:
+    - { target_kind: misc, target_key: emits_dim_light, modifier: 1 }
+  description: "Sheds dim light out to 10 feet."
+
+sharpness:
+  kind: weapon
+  value_premium_gp: 200
+  weight_delta: 0
+  scaling:
+    "+1": { damage_bonus: +1 }
+    "+2": { damage_bonus: +2 }
+    "+3": { damage_bonus: +3 }
+  description: "Magically keen edge; adds to damage."
+
+goblinbane:
+  kind: weapon
+  value_premium_gp: 150
+  effects:
+    - { target_kind: damage, target_key: vs_goblinoid, modifier: +2 }
+  description: "Bright red runes flare when a goblin is near. Extra damage against goblinoids."
+```
+
+Enchantments can scale (`tier` on `item_enchantments`), deplete (`charges`), or be static. `effects` entries in the enchantment definition are applied dynamically at check-resolution time, not inserted into the `effects` table — they're a property of the held item, not a temporary buff on the wielder.
+
+## Encumbrance — enforced
+
+Weight is computed, never stored. Capacity comes from content:
+
+```yaml
+# content/rules/encumbrance.yaml
+capacity_per_str:             15        # capacity = STR × 15 lb
+encumbered_threshold_pct:     67        # ≥67% of capacity → encumbered
+overloaded_threshold_pct:     100       # ≥100% → overloaded, cannot accept pickups
+```
+
+A character's carry readout is a single aggregation:
+
+```sql
+SELECT SUM(effective_weight(items))
+FROM items
+WHERE holder_character_id = ?
+   OR container_item_id IN (SELECT id FROM items WHERE holder_character_id = ?)
+```
+
+(Recursive for deeply-nested containers; SQLite handles this with a CTE.)
+
+### Enforcement
+
+- `inventory.pickup(character_id, item_id)` and `inventory.transfer(...)` **refuse** the action if it would push the recipient over 100% capacity. Returns `{ error: 'would_overload', current_weight, capacity }`.
+- Between 67% and 100% capacity, the MCP applies the `encumbered` condition (see [conditions](checks.md#conditions)) — which in content carries a `speed_penalty: -10` rider. The condition is re-evaluated whenever inventory changes.
+
+## Barter
+
+Items carry a computed `effective_value_gp`. The `barter.exchange` tool handles trades where the player is offering items (or gold) for other items:
+
+```
+barter.exchange(character_id, merchant_character_id, offered_item_ids, requested_item_ids)
+  computes: offered_value, requested_value
+  rolls: resolve_check(character_id, skill='persuasion', target=merchant,
+                       dc = 10 + haggle_difficulty_from_value_ratio)
+  applies: exchange_rate modifier based on roll result
+           (nat 20 → best terms; nat 1 → worst terms; middle → proportional)
+  executes: moves items; creates/consumes gold items as needed
+  emits: social.bargain event with full breakdown
+```
+
+The check outcome determines whether the player receives fair value, a bad deal, or a bonus. The exchange respects both sides of the transaction — merchants refuse manifestly bad deals (the player-offered value must be at least some content-configured fraction of the requested value).
+
+## Shops
+
+Shops are not a separate table. A shop is a **landmark** (see [world](world.md)) whose `corresponds_to_zone_id` points to a small zone containing the merchant (an NPC) whose inventory **is** the shop's stock. Buying from the shop is a barter exchange with the merchant; selling to the shop is the reverse.
+
+This keeps the world model uniform — a tavern is a zone, the innkeeper is a character, the kegs behind the bar are items held by the innkeeper. No special-purpose shop schema.
+
+## Tools
+
+| Tool                                                                     | Effect                                                                 |
+|--------------------------------------------------------------------------|------------------------------------------------------------------------|
+| `inventory.create(base_kind, holder_character_id?, zone_location_id?, container_item_id?, material?, material_tier?, quality?, quantity?, enchantments?)` | Create a new item instance; location must be specified. |
+| `inventory.transfer(item_id, to_character_id?, to_container_item_id?, to_zone_location_id?, quantity?)` | Move an item (or a quantity of a stackable) to a new location. |
+| `inventory.pickup(character_id, item_id, quantity?)`                     | Character picks up a zone-located item. Refuses if overloaded.         |
+| `inventory.drop(character_id, item_id, quantity?)`                       | Character drops an item into their current zone.                       |
+| `inventory.equip(character_id, item_id, slot)`                           | Set `equipped_slot`; validates against content's slot rules.           |
+| `inventory.unequip(character_id, item_id)`                               | Clear `equipped_slot`.                                                 |
+| `inventory.get(character_id)`                                            | Full inventory readout with effective stats and weight totals.         |
+| `inventory.inspect(item_id)`                                             | Effective stats of one item.                                           |
+| `barter.exchange(character_id, merchant_character_id, offered, requested)` | Barter flow; rolls persuasion, updates both inventories.             |

--- a/docs/npcs.md
+++ b/docs/npcs.md
@@ -1,0 +1,243 @@
+# NPC generation
+
+The world feels alive because new NPCs carry pre-existing history — crimes committed, relationships formed, agendas being pursued — and that history is woven into the campaign that's already in progress. This is the single feature that most strongly differentiates a coherent world from a procedurally-stitched one.
+
+## One table for every character
+
+NPCs use the exact same schema as the player and companions. See [characters](characters.md) for the full model. The only schema addition specific to NPC generation is:
+
+```
+characters.plans    TEXT?    -- prose: current agenda, motivations, goals
+```
+
+Everything else — stats, HP, AC, proficiencies, ideology, loyalty, role — already exists on `characters`. No NPC-specific table.
+
+**No `character_relationships` table.** Relationships are **implicit via event co-participation**: if two characters appear together in a `history.relationship.family` event, they're related. Same mechanism as recognition. See [history log](history-log.md).
+
+## Archetypes
+
+Archetypes describe **role + current faction**, not species essence. `orc_raider` is an orc who is currently raiding; `orc_merchant` is the same species in a completely different context. See [ideology and the anti-evil-races rule](#non-violent-resolution-first-class) below — this is a hard content-authoring rule.
+
+Archetype YAML lives in `content/npcs/archetypes/*.yaml`:
+
+```yaml
+# content/npcs/archetypes/orc_raider.yaml
+id: orc_raider
+species: orc
+role_hint: enemy                    # player | companion | friendly | enemy | neutral
+typical_age_years: [18, 45]
+
+stats:                              # rolled within each range
+  str: [14, 18]
+  dex: [10, 14]
+  con: [14, 18]
+  int: [6, 10]
+  wis: [8, 12]
+  cha: [6, 10]
+
+hp_formula: "3d8 + con_mod*3"
+ac_base: 13
+speed_ft: 30
+
+proficiencies:
+  - { name: 'save:str',      proficient: true }
+  - { name: 'save:con',      proficient: true }
+  - { name: 'intimidation',  proficient: true }
+  - { name: 'survival',      proficient: true }
+  - { name: 'greataxe',      proficient: true }
+
+loadout:                            # each entry rolled independently
+  - { base_kind: greataxe,      chance: 0.7, material: iron,    material_tier: 1 }
+  - { base_kind: handaxe,       chance: 0.5, material: iron,    material_tier: 1 }
+  - { base_kind: leather_armor, chance: 0.9, material: leather, material_tier: 1, equip: chest }
+  - { base_kind: gold,          chance: 1.0, quantity: "2d6" }
+
+plan_pool:                          # one picked at generation
+  - "Raiding nearby settlements for loot and captives"
+  - "Avenging the death of a clanmate killed by settlers"
+  - "Seeking a lost tribal relic taken during a settler raid"
+  - "Earning honour for their warband"
+
+ideology_pool:                      # one picked at generation
+  - "Strength is the only virtue worth respecting. The weak exist to be ruled."
+  - "Loyal only to the warband, suspicious of outsiders, honours debts in blood."
+
+social:
+  can_parley: true                  # default true
+  parley_requires: []               # [] = plain speech works
+hostile_triggers:
+  - "Encounter their warband in raided territory; strangers are presumed spies"
+
+peace_hooks:                        # prose; LLM uses when framing negotiation
+  - "Accepts a truce if offered blood-debt payment (3+ gold per clanmate lost)"
+  - "Will side-swap if shown convincing evidence of their war-chief's treachery"
+  - "Backs down if the party yields with dignity and leaves territory"
+  - "Can be recruited after defeating their leader in honourable single combat"
+
+backstory_hooks:                    # 3-5 rolled at generation; slots filled by reconciliation
+  - "Raided ${settlement} ${years_ago} years ago, after ${oppressor} ${past_wrong_against_orcs}"
+  - "Killed ${enemy_archetype} in single combat over ${cause}"
+  - "Fled from ${stronger_foe} after losing the duel"
+  - "Was exiled from ${tribe} for breaking a sacred law"
+  - "Carries a trophy taken from ${victim} at ${place}"
+```
+
+Name pools live in `content/npcs/name_pools/*.yaml` indexed by species or culture:
+
+```yaml
+orc:
+  first: [Grog, Zhar, Urgash, Maznok, ...]
+  last: [Skullcrusher, Ironfist, Bonebreaker, ...]
+human_northern:
+  first: [Bjorn, Inga, Sigrid, ...]
+```
+
+## Generation procedure
+
+`npc.generate(archetype, zone_id?, role_override?)`:
+
+1. **Load context** — the current campaign state: active NPCs, zones visited, unresolved plot threads, the big bad's moves, items the player is seeking. This is the input to the reconciliation pass.
+2. **Roll stats** in the archetype's ranges.
+3. **Compute HP** from the formula, using the rolled CON modifier.
+4. **Create the character row** with rolled stats, pool-picked ideology and plans, archetype id as `class_or_archetype`, `zone_id`, `status='alive'`, `role` from `role_hint` or the override.
+5. **Insert proficiencies** from the archetype.
+6. **Roll the loadout**: for each item entry, roll against `chance`; on success, create an `items` row with `holder_character_id = new character` and optional `equipped_slot`.
+7. **Pick a name** from the species/culture pool.
+8. **Synthesize backstory events** — 3 to 5, using the archetype's `backstory_hooks`. For each hook:
+   - Fill `${slot}` placeholders via the reconciliation pass (below).
+   - Pick a `campaign_hour` in the past — negative, representing years before campaign start.
+   - Insert a `history.backstory` event with this character and any referenced entities as participants.
+
+All of this runs in a single transaction.
+
+## Reconciliation
+
+The reconciliation pass is the mechanism that makes lazily-generated content feel like part of a coherent world. When `${slot}` placeholders in backstory hooks (or zone landmarks, or generated items) need filling, the pass prefers **existing entities** over inventing new ones:
+
+**Priority order for filling a slot:**
+
+1. An entity the player has **directly interacted with**. Highest narrative weight — creates recognition payoff when the player next encounters the NPC whose backstory references someone they've met.
+2. An entity the player has **heard of but not met**. Builds anticipation; confirms earlier rumors.
+3. An entity that **exists but no-one has encountered yet**. Enriches the world without a direct hook.
+4. **Generate a new stub entity**. Last resort — a long-dead ancestor, a distant village that may never be visited. Keep these minimal.
+
+Because the pass runs for zone generation, NPC generation, item placement, and any other mid-campaign content creation, the reconciliation logic is shared. Think of it as: *whenever the world grows, look for ways to tie the growth into what's already there.*
+
+This is why a blacksmith in village A might have a backstory that references an orc raid on village B — even if the player has only ever visited A. When the player later travels to B and meets its survivors, they already share a backstory element with someone the player knows.
+
+## Zone generation calls `npc.generate`
+
+Zone templates specify NPC slots, each pointing at an archetype:
+
+```yaml
+# content/world/zone_templates/village.yaml
+village_small:
+  npc_slots:
+    - { archetype: village_elder,    count: 1 }
+    - { archetype: tavern_keeper,    count: 1 }
+    - { archetype: blacksmith,       count: [0, 1] }
+    - { archetype: villager,         count: [4, 8] }
+    - { archetype: village_guard,    count: [1, 3] }
+```
+
+The zone generator rolls each slot's count and calls `npc.generate(archetype, zone_id=this_zone)` for each. Reconciliation runs across zones, so an NPC in one zone can reference history with an NPC in another zone.
+
+## Non-violent resolution (first-class)
+
+**No species is "evil by default".**
+
+Archetypes describe the role + current faction the character inhabits, not their inherent nature. Hostility is always traceable to situational cause:
+
+- An orc raid is a raid **because of** an oppression, a stolen artefact, a blood-debt from previous conflict.
+- A cultist is hostile **because** their ideology frames outsiders as prey or witnesses.
+- A bandit is hostile **because** they're desperate, coerced, or hired.
+
+Every hostility should be **resolvable without combat** in principle:
+
+| Target                      | Peaceful path                                          |
+|-----------------------------|--------------------------------------------------------|
+| Sapient hostile (raider, cultist) | Negotiation, side-swap, bribery, intimidation, revelation |
+| Animal-intelligence creature | Animal handling, `speak_with_animals`, food, terrain    |
+| Mindless (skeleton, ooze)    | Destruction, control magic, avoidance — `can_parley: false` |
+
+### Content-authoring rules
+
+- **No alignment axis** in archetype YAML. No `alignment: evil`, no `tends_hostile: true`.
+- **Backstory hooks carry causes, not just acts**: `"Raided ${settlement} after ${oppressor} enslaved ${relation}"` not just `"Raided ${settlement}"`. The reconciliation pass can then wire the cause to existing campaign threads.
+- **Every hostile encounter** (see [encounters](encounters.md#resolution-paths)) must have at least one peaceful `resolution_path` — unless all participants are truly mindless.
+
+### Archetype's social block
+
+Two fields on the archetype gate the check-based peaceful paths:
+
+```yaml
+social:
+  can_parley: true                    # default true; false only for mindless
+  parley_requires: []                 # e.g. ['speak_with_animals'] for beasts
+```
+
+`resolve_check` of kind `persuade`/`deceive`/`intimidate` is **refused** if the target's archetype has `can_parley: false`. For `parley_requires: [...]`, the agent reads this and either satisfies the requirement (via an effect granting the required ability) or knows the plain-speech route is unavailable.
+
+INT score drives interpretation at the edges:
+- `int: [1, 3]` → mindless; typically `can_parley: false`.
+- `int: [3, 7]` → animal-level; `parley_requires: ['speak_with_animals']` or requires Animal Handling.
+- `int: [8+]` → sapient; ordinary speech works.
+
+### Hostile triggers
+
+Some archetypes have contexts that make them **reflexively hostile** — not because of who they are, but because of where they are or what they're doing:
+
+```yaml
+hostile_triggers:
+  - "Anyone not wearing the cult's sigil is potential prey or witness"
+  - "Outsiders encountered near ritual sites are presumed hostile"
+```
+
+When a trigger fires on first contact, it biases the initial ideology-alignment tier toward `very_misaligned`. The trigger is not unbreakable — a clever approach (disguise, false sigil, appeal to demon-lord hierarchy) can sidestep it — but it raises the DC of peaceful first contact significantly.
+
+### Role swaps are first-class
+
+When the player's actions reveal that an "enemy" had a legitimate grievance and a new alliance forms, `character.change_role(character_id, new_role, reason)` captures the pivot:
+
+- Emits `npc.role_changed` with before/after role values and the narrative reason.
+- The audit trail lets later queries answer "when did this NPC become an ally?"
+- The full mechanic of side-swapping (villager becomes enemy after betrayal, enemy becomes companion after reconciliation) is **just a column update + an event**. No state machine.
+
+## Recall and recognition
+
+One generic tool covers "what does the player remember" and "what does this NPC know":
+
+```
+character.recall(character_id, {
+  zone_id?,
+  other_character_id?,
+  other_item_id?,
+  kind_prefix?,
+  since_hour?,
+  limit?
+})
+  → list of events this character participated in
+    (as actor | target | witness | beneficiary),
+    filtered by the optional criteria,
+    newest-first (but `since_hour=<negative>` includes pre-campaign backstory).
+```
+
+"What does villager Bob know about this orc?" → `character.recall(bob.id, { other_character_id: orc.id })`. If Bob was a witness-role participant in the orc's raid-on-Ashfield backstory event, that event comes back — and the agent can narrate Bob's recognition naturally.
+
+Same indexed query path serves both real-play recall and pre-campaign backstory recognition. The event log doesn't distinguish between "this happened in play" and "this was synthesized at NPC generation."
+
+## Tools
+
+| Tool                                                         | Effect                                                                |
+|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `npc.generate(archetype, zone_id?, role_override?)`          | Create an NPC with rolled stats, loadout, and synthesized backstory.  |
+| `character.recall(character_id, filters)`                    | Events this character participated in. See above.                     |
+| `character.update_plans(character_id, new_plans, source_event_id)` | Overwrite plans; emit `npc.plan_changed`.                       |
+| `character.change_role(character_id, new_role, reason)`      | Side-swap; emits `npc.role_changed`.                                  |
+
+## Deferred
+
+- **Autonomous NPC behaviour between sessions.** Plans advancing without the player present. Post-MVP.
+- **Formal faction system.** Factions are currently implicit in shared archetypes + shared backstory events. A dedicated `factions` table may be added later if queries like "which NPCs belong to the cult" become common.
+- **Explicit `character_relationships` table.** Relationships are currently derived from event co-participation. A dedicated table would be a denormalisation for performance; not needed yet.
+- **Dynamic alignment shifts with complex state machines.** Role change is a single column update + an event — intentionally simple. More nuanced shifts (partial alignment, reversible betrayals) can be layered via additional event kinds without schema change.

--- a/docs/world.md
+++ b/docs/world.md
@@ -1,0 +1,194 @@
+# World, zones & maps
+
+## Shape
+
+The world is a **directed graph of zones**. Each zone is a narrative node with a prose description, not a tile map. Hex grids are deferred — possibly forever, certainly for MVP — but the design avoids choices that would fight a later hex layer.
+
+The player moves through the graph zone by zone. What they know of the world is per-character fog of war. Internal structure of a zone (a dungeon's rooms and floors) uses the **same `zones` table**, with `parent_zone_id` giving nested structure.
+
+## Schema
+
+```
+zones(
+    id                    PK,
+    name                  TEXT,
+    biome                 TEXT,             -- content key: forest, mountains, settlement, dungeon_stone, ...
+    kind                  TEXT,             -- wilderness | settlement | dungeon | dungeon_floor | dungeon_room | road | liminal
+    size                  TEXT,             -- tiny | small | medium | large | vast
+    parent_zone_id        FK?,              -- nested zones: dungeon → floor → room
+    description           TEXT,             -- prose for the agent
+    encounter_tags        TEXT,             -- JSON array of tags indexing into encounter content
+    created_at_event_id   FK?,
+    notes                 TEXT?
+)
+
+zone_connections(
+    from_zone_id          FK,
+    to_zone_id            FK,
+    travel_time_hours     INTEGER,          -- world-hours to traverse
+    travel_mode           TEXT,             -- road | wilderness | portal | passage | climb
+    hazard_tag            TEXT?,            -- biases random-encounter rolls in transit
+    one_way               BOOL,             -- waterfalls, one-way portals
+    direction_from        TEXT,             -- n | ne | e | se | s | sw | w | nw | up | down
+    PRIMARY KEY (from_zone_id, to_zone_id)
+)
+
+landmarks(
+    id                    PK,
+    zone_id               FK,
+    name                  TEXT,
+    kind                  TEXT,             -- settlement | dungeon_entrance | shop | temple | ruin | natural_feature
+    description           TEXT,
+    position_note         TEXT?,            -- free-text: 'at the north end', 'atop the hill'
+    hidden                BOOL,             -- secret landmarks start hidden; revealed by discovery events
+    corresponds_to_zone_id FK?,             -- if entering this landmark puts you in a different zone
+    created_at_event_id   FK?
+)
+
+character_zone_knowledge(
+    character_id          FK,
+    zone_id               FK,
+    level                 TEXT,             -- rumored | known | visited | mapped
+    first_event_id        FK?,              -- event that granted this knowledge
+    last_visit_at_hour    INTEGER?,
+    PRIMARY KEY (character_id, zone_id)
+)
+
+character_landmark_knowledge(
+    character_id          FK,
+    landmark_id           FK,
+    level                 TEXT,             -- rumored | known | visited
+    first_event_id        FK?,
+    last_visit_at_hour    INTEGER?,
+    PRIMARY KEY (character_id, landmark_id)
+)
+```
+
+## Key decisions
+
+### Graph, not hex grid
+
+The world is zones-as-nodes and connections-as-directed-edges. Hex grids were considered and deferred because:
+
+- Graphs represent narrative geography naturally. "Greenhollow Forest" is a single zone; it doesn't need tile-by-tile authoring.
+- The MVP consumer is an LLM DM agent that narrates space — it doesn't need tactical coordinates.
+- Hex grids would triple the authoring load (generate terrain for every tile) for minimal gameplay gain at this stage.
+
+**Forward compatibility with hexes is maintained** by the `direction_from` column on connections. When adding a hex layer later, zones gain hex coordinates and connections imply cell adjacency; the graph structure remains valid as a coarser "region" overlay. Nothing in the current design blocks that.
+
+### Directed edges, two rows per bidirectional connection
+
+Most connections are bidirectional, so they show up as two rows: A→B and B→A. This costs a bit of storage and makes `one_way` asymmetries trivially representable. "Where can I go from here?" is a single indexed query on `from_zone_id` with no `OR` / `UNION` gymnastics.
+
+### `direction_from` is the minimum spatial data we need
+
+One column unblocks world-map rendering today (place zones in 2D by walking directions from the starting zone) and maps cleanly onto hex neighbours later (8 horizontal directions + up/down align with hex conventions). Without it, the graph is purely topological and later spatial layouts require guessing.
+
+### Nested zones for complex structures, flat for simple ones
+
+A **dungeon** is a zone with `kind='dungeon'`. Each of its floors is a child zone with `kind='dungeon_floor'` and `parent_zone_id = dungeon`. Each of a floor's rooms is a child with `kind='dungeon_room'` and `parent_zone_id = floor`. Stairs between floors are `zone_connections` with `direction_from='up'` or `'down'`.
+
+A **single-space encounter** — a forest clearing ambush, a roadside meeting — stays flat: one zone with `kind='wilderness'`, participants placed without sub-rooms, no children. The nesting is proportional to structural complexity.
+
+### Fog-of-war knowledge is per-character, monotonic upward
+
+Knowledge levels form a strict order: `rumored < known < visited < mapped`. Once a character has a knowledge level, they don't lose it except through an explicit event (magical memory loss, supernatural amnesia) which is a rare, deliberate action.
+
+`mapped` exists only for zones (buying or finding a map of a region); landmarks, being points rather than areas, top out at `visited`.
+
+Per-character rather than per-party because:
+- A newly-met companion hasn't visited the places the player has. The companion can be told ("I've been to Ashfield — it's two days north"), which inserts a `rumored` row for them.
+- "What does this NPC know about the world?" uses the same queries as "what does the player know."
+
+### Landmarks can reference zones
+
+A settlement is usually both a landmark (visible in its containing wilderness zone) **and** a zone of its own (for when the player is inside it). `landmarks.corresponds_to_zone_id` links them:
+
+- The forest zone contains a landmark `{name: "Ashfield", corresponds_to_zone_id: ashfield_zone.id}`.
+- Entering Ashfield via `world.travel(character, ashfield_zone.id)` is normal travel; the landmark is just a visual/narrative anchor for the approach.
+
+## Lazy generation
+
+The world grows outward from the player. It is **not** fully generated at campaign start.
+
+### Two levels of generation
+
+**Stub generation** runs on adjacency discovery. When the player enters a zone, its direct neighbours are ensured to exist as stub rows: `{name, biome, kind, size}` plus a `zone_connection` back. No landmarks, no internal detail, no NPCs. Cheap and fast.
+
+**Full generation** runs on first visit. When a character's `character_zone_knowledge.level` upgrades from `rumored`/`known` → `visited` for the first time, the full generator fires and populates the zone with landmarks, encounter-tag pool, resident NPCs, and pre-history events.
+
+Full generation happens **once per zone** and caches its result in the database; re-entries are free.
+
+### Why lazy — and why this feels "alive"
+
+The full-generation pass runs **with read access to the entire campaign state**: the event log, all NPCs known to exist, active plot threads, the big bad's recent moves, items the player is seeking.
+
+Before placing a new landmark or NPC, the generator asks: *can an existing entity fit here?* An orc the player has fought could turn up here. The big bad's known agents could have reached this region. A lost item from an earlier backstory event could surface in this landmark.
+
+This is the **reconciliation pass** (see [NPC generation](npcs.md#reconciliation)) — and it's the reason lazily-generated zones feel like part of a single coherent world rather than procedurally-stitched bits. Every late-discovered zone can be woven into the established narrative because the generator sees the full narrative when it runs.
+
+## Dungeons
+
+Dungeon generation is template-driven procedural. A dungeon template lives in content:
+
+```yaml
+# content/world/dungeon_templates.yaml
+abandoned_wizard_tower:
+  floor_count: "1d4+2"              # 3-6 floors
+  rooms_per_floor: "2d4+2"          # 4-10 rooms
+  connection_density: 0.5           # probability of a non-tree edge between two rooms on the same floor
+  encounter_tags: [undead, arcane_guardians, magical_traps]
+  landmark_kinds: [library, laboratory, summoning_circle, sanctum]
+  boss_depth: last_floor
+  treasure_depth: middle_or_last
+```
+
+Procedure:
+
+1. Create parent zone, `kind='dungeon'`, biome from template.
+2. Roll `floor_count`; create that many child zones (parent=dungeon), `kind='dungeon_floor'`.
+3. For each floor, roll `rooms_per_floor`; create child zones (parent=floor), `kind='dungeon_room'`.
+4. Connect rooms on each floor: start with a spanning tree (ensures connectivity), then add extra edges up to the density parameter.
+5. Connect floors via stairs: pick one room per floor as stair-up, another as stair-down; add connections with `direction_from='up'`/`'down'`.
+6. Assign encounters from the tag pool, weighted by depth (harder encounters deeper).
+7. Place landmarks per template (boss room on last floor, treasure room biased toward middle/last).
+
+Bounded, deterministic given seeds, and entirely content-controlled.
+
+## Travel
+
+`world.travel(character_id, to_zone_id)`:
+
+1. Validate: `zone_connections` contains an edge from `character.current_zone_id` to `to_zone_id`.
+2. Advance `campaign_hour` by the edge's `travel_time_hours`; tick hour-based effect/condition expiries.
+3. Roll for a random encounter using the destination biome's `encounter_tags` combined with the connection's `hazard_tag`.
+4. Update `characters.current_zone_id`.
+5. Upsert `character_zone_knowledge` to `visited` if the level was lower.
+6. Trigger stub-generation for any of the destination's neighbours that don't yet exist.
+7. Trigger full-generation of the destination zone if this is the first visit.
+8. Emit events: `location.move`, optionally `encounter.rolled`, generation events for any new zones/landmarks/NPCs created.
+
+Travel is where world time actually advances in coherent chunks — the clock ticks forward, maybe an encounter interrupts, visibility updates.
+
+## World map
+
+`world.map(character_id)` returns a fog-filtered graph the agent can render (ASCII, text, or piped to a viz client):
+
+- **Zones** the asking character has at least `rumored` knowledge of, each with its current knowledge level.
+- **Connections** between zones where both endpoints are at least `known` (or one `visited` + one `rumored` — the edge is known, the destination hazy).
+- **Landmarks** the asking character has at least `rumored` knowledge of.
+- **Computed 2D positions** for each zone, derived from `direction_from` on connections with the character's current zone as origin `(0, 0)`.
+
+The output is structured JSON; rendering is the agent's job. For MVP, an ASCII-art rendering companion tool can be added, but the MCP guarantees only the structured graph.
+
+## Tools
+
+| Tool                                                        | Effect                                                                 |
+|-------------------------------------------------------------|------------------------------------------------------------------------|
+| `world.travel(character_id, to_zone_id)`                    | Move + advance time + roll encounter + update fog. Described above.    |
+| `world.map(character_id)`                                   | Fog-filtered structured graph with 2D positions.                       |
+| `world.describe_zone(character_id, zone_id?)`               | Prose + landmarks + NPCs for a zone the character has visited.         |
+| `world.list_connections(character_id)`                      | "Where can I go from here?" — filtered by knowledge level.             |
+| `world.reveal_landmark(character_id, landmark_id)`          | Bump the character's landmark knowledge level.                         |
+| `world.learn_of_zone(character_id, zone_id, level)`         | Grant rumored/known knowledge (NPC tells the player about a place).    |
+| `world.generate_zone(from_zone_id, direction, biome_hint?)` | Admin/testing; normally triggered automatically by travel.             |


### PR DESCRIPTION
## Summary

Design-only PR capturing the complete architectural specification for dm-mcp as the solo-RPG DM MCP toolkit. No code is shipped in this PR — the current \`src/\` (dice-rolling stub + bespoke JSON stdio loop + placeholder httpstream) is left untouched. Phase 1 will replace the stub with a real MCP skeleton in a follow-up PR.

## What lands

- **\`CLAUDE.md\`** — session orientation for Claude Code: hard rules (rustls-only TLS, no WotC IP, content-is-data, latency commitments, single-campaign-per-process, no-alignment-axis), key architectural decisions with pointers to docs, per-phase workflow, current stub caveats (auto-deleted when Phase 1 lands).
- **\`README.md\`** — rewritten overview, env-var configuration table, Kubernetes deployment snippet, and the 10-phase implementation Roadmap with per-phase E2E test assertions and checkboxes/PR links.
- **\`docs/\`** — 13 design documents (~2000 lines) covering every subsystem:
  - \`architecture.md\` — transport, deployment, latency, config
  - \`history-log.md\` — polymorphic events, two-tier time, participants/items junctions
  - \`characters.md\` — unified entity model, parties, loyalty, ideology, death flow
  - \`checks.md\` — resolve_check pipeline, effects, conditions, proficiencies, ideology-alignment rubric
  - \`items.md\` — single-table items, materials, enchantments, currency, encumbrance, barter
  - \`world.md\` — zones, connections, fog of war, lazy generation, dungeons
  - \`encounters.md\` — goal-not-kill XP, combat as encounter mode, resolution paths, stale cleanup
  - \`npcs.md\` — archetypes, reconciliation, non-violent resolution, recall
  - \`campaign-setup.md\` — bootstrap phase + pre-history synthesis
  - \`content.md\` — content directory layout, YAML loading, \`DMMCP_CONTENT_DIR\` override
  - \`ip-and-licensing.md\` — SRD/ORC content rule, no WotC branding
  - \`README.md\` — docs index

## Test plan

- [x] Design docs rendered and cross-linked
- [x] Roadmap in README tracks the 10 phases with E2E assertions
- [x] CLAUDE.md covers hard rules without needing external context
- [x] No executable code changes (current stub unchanged; \`cargo check\` still passes in its pre-redesign shape)

## What's next

- **Phase 1 — Skeleton** (\`feature/phase-1-skeleton\`): removes the stub, introduces rmcp with dual transport, \`/healthz\`, \`server.info\` tool, and \`DMMCP_\` env var config. First PR with actual code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded project documentation as `dm-mcp`, an MCP toolkit for solo RPG campaign management.
  * Added comprehensive design documentation covering system architecture, campaign setup, characters, encounters, world generation, items, checks, history/event logs, and IP/licensing constraints.
  * Added developer guide for contributing to the project.
  * Updated README with pre-MVP status, phased roadmap, environment configuration details, and Kubernetes deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->