### PR TITLE
Tooling: Makefile for local dev + manual testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 /target
+
+# Makefile runtime artefacts — server PIDs and logs written by `make dev`.
+/.pids
+/.logs
+
+# Local campaign databases (incl. WAL sidecars) created by the dev server.
+/campaign.db
+/campaign.db-wal
+/campaign.db-shm

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 #
 #   make dev         Build + start the server over HTTP for manual testing
 #   make run-stdio   Attach the stdio transport to this terminal
+#   make demo        Walkthrough: spawn stdio, handshake, list tools, call server.info
 #   make clean       Stop the dev server, wipe build artefacts and logs
 #   make logs        Tail the dev server log
-#   make test        Run the full test suite (cargo test)
+#   make test        Run the full automated test suite (cargo test)
 #   make check       Run all CI quality gates locally — matches ci.yaml
 #   make audit       cargo audit + verify rustls-only — matches commit.yaml
 #   make build       Release build (scratch-container target)
@@ -25,7 +26,7 @@ LOG_DIR     := .logs
 PID_DIR     := .pids
 
 # ─────────────────────────────────────────────────────────────────────────────
-.PHONY: dev run-stdio clean logs test check audit build reset health \
+.PHONY: dev run-stdio demo clean logs test check audit build reset health \
         _build-debug _service-start _service-stop _sweep-stale \
         _check-fmt _check-clippy _check-no-openssl
 
@@ -62,6 +63,24 @@ run-stdio:
 	@DMMCP_DB_PATH=$(DB_PATH) \
 	 DMMCP_LOG_LEVEL=$(LOG_LEVEL) \
 	 cargo run --quiet -- stdio
+
+# ─────────────────────────────────────────────────────────────────────────────
+## demo: Manual-test walkthrough — spawn stdio, handshake, call server.info
+##      Builds the debug binary, then runs examples/manual_demo, which acts as
+##      a real MCP client:
+##        1. spawns dm-mcp as an MCP stdio child process
+##        2. completes the MCP handshake
+##        3. lists the registered tools
+##        4. calls server.info and pretty-prints the JSON response
+##        5. cancels the session cleanly
+##      Every step prints what the client sees — use this when you want to
+##      eyeball the server's responses without running the full test suite.
+##
+##      To see the raw JSON-RPC frames on stderr:
+##        RUST_LOG=rmcp=trace make demo
+# ─────────────────────────────────────────────────────────────────────────────
+demo: _build-debug
+	@cargo run --quiet --example manual_demo
 
 # ─────────────────────────────────────────────────────────────────────────────
 ## clean: Stop the dev server and wipe build artefacts

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ demo: _build-debug
 # ─────────────────────────────────────────────────────────────────────────────
 clean: _service-stop
 	@cargo clean
-	@rm -rf $(LOG_DIR) $(PID_DIR)
+	@rm -rf -- "$(LOG_DIR)" "$(PID_DIR)"
 	@echo "✓ Cleaned"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -170,7 +170,7 @@ build:
 # ─────────────────────────────────────────────────────────────────────────────
 reset: _service-stop
 	@echo "→ Removing $(DB_PATH) (+ WAL sidecars)..."
-	@rm -f $(DB_PATH) $(DB_PATH)-wal $(DB_PATH)-shm
+	@rm -f -- "$(DB_PATH)" "$(DB_PATH)-wal" "$(DB_PATH)-shm"
 	@echo "✓ Campaign database wiped"
 	@echo "  Run 'make dev' to start with a fresh campaign."
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,295 @@
+# ─── dm-mcp Development Makefile ─────────────────────────────────────────────
+#
+#   make dev         Build + start the server over HTTP for manual testing
+#   make run-stdio   Attach the stdio transport to this terminal
+#   make clean       Stop the dev server, wipe build artefacts and logs
+#   make logs        Tail the dev server log
+#   make test        Run the full test suite (cargo test)
+#   make check       Run all CI quality gates locally — matches ci.yaml
+#   make audit       cargo audit + verify rustls-only — matches commit.yaml
+#   make build       Release build (scratch-container target)
+#   make reset       Wipe the campaign SQLite file for a fresh run
+#   make health      Smoke test: curl /healthz on the dev server
+#
+# Requires: cargo, curl
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Runtime config (mirrors the DMMCP_ env var contract; see README) ──────────
+HTTP_BIND   := 127.0.0.1
+HTTP_PORT   := 3000
+DB_PATH     := ./campaign.db
+LOG_LEVEL   := info
+
+# ── Directory layout ──────────────────────────────────────────────────────────
+LOG_DIR     := .logs
+PID_DIR     := .pids
+
+# ─────────────────────────────────────────────────────────────────────────────
+.PHONY: dev run-stdio clean logs test check audit build reset health \
+        _build-debug _service-start _service-stop _sweep-stale \
+        _check-fmt _check-clippy _check-no-openssl
+
+# ─────────────────────────────────────────────────────────────────────────────
+## dev: Start the HTTP transport for manual testing
+##      Builds the debug binary, spawns it in the background on HTTP_PORT,
+##      waits for /healthz to respond, and hands control back. Use an MCP
+##      client (Claude / Cursor / MCP Inspector) pointed at /mcp to exercise
+##      tool calls.
+# ─────────────────────────────────────────────────────────────────────────────
+dev: _build-debug _service-start
+	@echo ""
+	@echo "┌─────────────────────────────────────────────┐"
+	@echo "│  dm-mcp dev server is running               │"
+	@echo "│                                             │"
+	@echo "│  Transport  →  HTTP                         │"
+	@echo "│  Bind       →  http://$(HTTP_BIND):$(HTTP_PORT)         │"
+	@echo "│  MCP path   →  /mcp                         │"
+	@echo "│  Probe      →  /healthz                     │"
+	@echo "│  Campaign   →  $(DB_PATH)                 │"
+	@echo "│                                             │"
+	@echo "│  make health  smoke-test /healthz           │"
+	@echo "│  make logs    tail the server log           │"
+	@echo "│  make clean   stop + wipe artefacts         │"
+	@echo "└─────────────────────────────────────────────┘"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## run-stdio: Attach the stdio transport to this terminal
+##      Useful when piping MCP JSON-RPC frames by hand, or when a local client
+##      (e.g. Claude Code) is configured to spawn dm-mcp as a child process.
+##      Ctrl-C or stdin EOF to stop.
+# ─────────────────────────────────────────────────────────────────────────────
+run-stdio:
+	@DMMCP_DB_PATH=$(DB_PATH) \
+	 DMMCP_LOG_LEVEL=$(LOG_LEVEL) \
+	 cargo run --quiet -- stdio
+
+# ─────────────────────────────────────────────────────────────────────────────
+## clean: Stop the dev server and wipe build artefacts
+##      Does not drop the campaign database. Use `make reset` for that.
+# ─────────────────────────────────────────────────────────────────────────────
+clean: _service-stop
+	@cargo clean
+	@rm -rf $(LOG_DIR) $(PID_DIR)
+	@echo "✓ Cleaned"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## logs: Tail the dev server log
+# ─────────────────────────────────────────────────────────────────────────────
+logs:
+	@if [ ! -f "$(LOG_DIR)/dm-mcp.log" ]; then \
+		echo "No log file at $(LOG_DIR)/dm-mcp.log"; \
+		echo "Run 'make dev' first."; \
+		exit 1; \
+	fi
+	@echo "Tailing: $(LOG_DIR)/dm-mcp.log"
+	@tail -f $(LOG_DIR)/dm-mcp.log
+
+# ─────────────────────────────────────────────────────────────────────────────
+## test: Run the full test suite
+##      Unit tests (src/**/tests) + integration tests (tests/*.rs — spawn
+##      the compiled binary and drive it through real MCP protocol over
+##      stdio and HTTP). No external services.
+# ─────────────────────────────────────────────────────────────────────────────
+test:
+	@echo "→ Running tests (unit + integration)..."
+	@cargo test
+	@echo "✓ Tests passed"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## check: Run all CI quality gates locally
+##      Mirrors .github/workflows/ci.yaml so if this passes, CI will pass.
+##      Run before raising a PR.
+##
+##      Steps (in order):
+##        1. cargo fmt --all -- --check
+##        2. cargo clippy --all-targets -- -D warnings
+##        3. cargo tree -i openssl|openssl-sys|native-tls (must be empty)
+##        4. cargo test
+##
+##      Release build (cargo build --release) is verified in CI but not
+##      here — it costs minutes on a Pi. Run `make build` explicitly if you
+##      want to reproduce that locally.
+# ─────────────────────────────────────────────────────────────────────────────
+check: _check-fmt _check-clippy _check-no-openssl test
+	@echo ""
+	@echo "┌─────────────────────────────────────────────┐"
+	@echo "│  All quality gates passed.                  │"
+	@echo "│  This branch is ready to PR.                │"
+	@echo "└─────────────────────────────────────────────┘"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## audit: Security audit — matches .github/workflows/commit.yaml
+##      Re-verifies the rustls-only rule and runs `cargo audit` against the
+##      RustSec advisory database. Installs cargo-audit on demand; a cold
+##      install is slow on ARM (~30 min). CI caches the binary.
+# ─────────────────────────────────────────────────────────────────────────────
+audit: _check-no-openssl
+	@echo "→ Running cargo audit..."
+	@command -v cargo-audit > /dev/null || { \
+		echo "  cargo-audit not found — installing (this may take a while)..."; \
+		cargo install cargo-audit --locked; \
+	}
+	@cargo audit
+	@echo "✓ No advisories"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## build: Release build
+##      Statically-linked binary suitable for the scratch container image.
+##      See target/release/dm-mcp after the build completes.
+# ─────────────────────────────────────────────────────────────────────────────
+build:
+	@echo "→ Building release binary..."
+	@cargo build --release
+	@echo "✓ $$(ls -lh target/release/dm-mcp | awk '{print $$5, $$9}')"
+
+# ─────────────────────────────────────────────────────────────────────────────
+## reset: Wipe the campaign database
+##      Stops the dev server if running, removes $(DB_PATH) and its WAL
+##      sidecars, leaves everything else intact.
+##
+##      CAUTION: destroys all in-campaign state.
+# ─────────────────────────────────────────────────────────────────────────────
+reset: _service-stop
+	@echo "→ Removing $(DB_PATH) (+ WAL sidecars)..."
+	@rm -f $(DB_PATH) $(DB_PATH)-wal $(DB_PATH)-shm
+	@echo "✓ Campaign database wiped"
+	@echo "  Run 'make dev' to start with a fresh campaign."
+
+# ─────────────────────────────────────────────────────────────────────────────
+## health: GET /healthz on the dev server
+##      Smoke test that the HTTP transport is up and answering.
+# ─────────────────────────────────────────────────────────────────────────────
+health:
+	@echo "→ GET http://$(HTTP_BIND):$(HTTP_PORT)/healthz"
+	@curl -fsS http://$(HTTP_BIND):$(HTTP_PORT)/healthz || { \
+		echo ""; \
+		echo "✗ /healthz failed. Is 'make dev' running?"; \
+		exit 1; \
+	}
+	@echo ""
+	@echo "✓ /healthz OK"
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Internal helper targets (not intended to be called directly)
+# ══════════════════════════════════════════════════════════════════════════════
+
+_build-debug:
+	@echo "→ Building debug binary..."
+	@cargo build --quiet
+	@echo "✓ Build complete"
+
+# ── Service management ────────────────────────────────────────────────────────
+#
+# Single binary, single port. PID is written to $(PID_DIR)/dm-mcp.pid and
+# stdout/stderr go to $(LOG_DIR)/dm-mcp.log. Start sweeps any stale process
+# from this checkout before spawning (see _sweep-stale).
+
+_service-start: _sweep-stale
+	@mkdir -p $(LOG_DIR) $(PID_DIR)
+	@echo "→ Starting dm-mcp on http://$(HTTP_BIND):$(HTTP_PORT)..."
+	@DMMCP_HTTP_BIND="$(HTTP_BIND)" \
+	 DMMCP_HTTP_PORT="$(HTTP_PORT)" \
+	 DMMCP_DB_PATH="$(DB_PATH)" \
+	 DMMCP_LOG_LEVEL="$(LOG_LEVEL)" \
+	 ./target/debug/dm-mcp http > $(LOG_DIR)/dm-mcp.log 2>&1 & \
+	 echo $$! > $(PID_DIR)/dm-mcp.pid
+	@printf "  Waiting for /healthz"
+	@for i in $$(seq 1 50); do \
+		if curl -sf http://$(HTTP_BIND):$(HTTP_PORT)/healthz > /dev/null 2>&1; then \
+			echo " ready"; \
+			echo "  pid: $$(cat $(PID_DIR)/dm-mcp.pid) — log: $(LOG_DIR)/dm-mcp.log"; \
+			exit 0; \
+		fi; \
+		if ! kill -0 "$$(cat $(PID_DIR)/dm-mcp.pid)" 2>/dev/null; then \
+			echo ""; \
+			echo "✗ dm-mcp exited before /healthz came up. Last log lines:"; \
+			tail -n 20 $(LOG_DIR)/dm-mcp.log; \
+			rm -f $(PID_DIR)/dm-mcp.pid; \
+			exit 1; \
+		fi; \
+		printf '.'; sleep 0.2; \
+	done; \
+	echo ""; \
+	echo "✗ Server did not come up within 10s. See $(LOG_DIR)/dm-mcp.log"; \
+	exit 1
+
+_service-stop: _sweep-stale
+	@if [ -f "$(PID_DIR)/dm-mcp.pid" ]; then \
+		pid=$$(cat "$(PID_DIR)/dm-mcp.pid"); \
+		if kill -0 "$$pid" 2>/dev/null; then \
+			kill "$$pid" && echo "✓ Stopped dm-mcp (pid: $$pid)"; \
+		fi; \
+		rm -f "$(PID_DIR)/dm-mcp.pid"; \
+	fi
+
+# Catch-all: kill any dm-mcp binary from THIS checkout left behind by an earlier
+# session (crash, SSH disconnect, $(PID_DIR) wiped). Match by process name (-x
+# means exact — pgrep doesn't see the make subshell), then filter by
+# /proc/<pid>/cwd so we never touch a dm-mcp started from a different checkout
+# on a shared machine. SIGTERM → wait 1s → SIGKILL any holdouts. Silent when
+# nothing is running. Linux-only (uses /proc).
+_sweep-stale:
+	@candidates=$$(pgrep -x dm-mcp 2>/dev/null || true); \
+	pids=""; \
+	for pid in $$candidates; do \
+		cwd=$$(readlink /proc/$$pid/cwd 2>/dev/null || true); \
+		if [ "$$cwd" = "$(CURDIR)" ]; then \
+			pids="$$pids $$pid"; \
+		fi; \
+	done; \
+	pids=$$(echo $$pids | xargs); \
+	if [ -n "$$pids" ]; then \
+		echo "→ Sweeping stale dm-mcp processes: $$pids"; \
+		kill $$pids 2>/dev/null || true; \
+		sleep 1; \
+		stubborn=""; \
+		for pid in $$pids; do \
+			if kill -0 $$pid 2>/dev/null; then stubborn="$$stubborn $$pid"; fi; \
+		done; \
+		stubborn=$$(echo $$stubborn | xargs); \
+		if [ -n "$$stubborn" ]; then \
+			echo "  forcing: $$stubborn"; \
+			kill -9 $$stubborn 2>/dev/null || true; \
+		fi; \
+		echo "✓ Stale processes cleared"; \
+	fi
+
+# ── Quality gates (matches .github/workflows/ci.yaml) ─────────────────────────
+
+_check-fmt:
+	@echo "→ Checking formatting..."
+	@cargo fmt --all -- --check || { \
+		echo ""; \
+		echo "✗ Formatting check failed."; \
+		echo "  Run: cargo fmt --all"; \
+		exit 1; \
+	}
+	@echo "✓ Formatting OK"
+
+_check-clippy:
+	@echo "→ Running clippy (warnings as errors)..."
+	@cargo clippy --all-targets -- -D warnings || { \
+		echo ""; \
+		echo "✗ Clippy check failed."; \
+		echo "  Fix all warnings before raising a PR."; \
+		exit 1; \
+	}
+	@echo "✓ Clippy OK"
+
+_check-no-openssl:
+	@echo "→ Verifying rustls-only TLS (no openssl / openssl-sys / native-tls)..."
+	@fail=0; \
+	for crate in openssl openssl-sys native-tls; do \
+		if cargo tree -i "$$crate" > /dev/null 2>&1; then \
+			echo "  ✗ $$crate is in the dependency tree:"; \
+			cargo tree -i "$$crate" | sed 's/^/    /'; \
+			fail=1; \
+		fi; \
+	done; \
+	if [ "$$fail" = "1" ]; then \
+		echo ""; \
+		echo "✗ OpenSSL / native-tls detected. Project rule: rustls only."; \
+		echo "  Swap the offender for a rustls variant, or disable its default features."; \
+		exit 1; \
+	fi
+	@echo "✓ No OpenSSL / native-tls in tree"

--- a/Makefile
+++ b/Makefile
@@ -212,24 +212,34 @@ _service-start: _sweep-stale
 	 DMMCP_LOG_LEVEL="$(LOG_LEVEL)" \
 	 ./target/debug/dm-mcp http > $(LOG_DIR)/dm-mcp.log 2>&1 & \
 	 echo $$! > $(PID_DIR)/dm-mcp.pid
-	@printf "  Waiting for /healthz"
-	@for i in $$(seq 1 50); do \
-		if curl -sf http://$(HTTP_BIND):$(HTTP_PORT)/healthz > /dev/null 2>&1; then \
-			echo " ready"; \
-			echo "  pid: $$(cat $(PID_DIR)/dm-mcp.pid) — log: $(LOG_DIR)/dm-mcp.log"; \
-			exit 0; \
-		fi; \
-		if ! kill -0 "$$(cat $(PID_DIR)/dm-mcp.pid)" 2>/dev/null; then \
+	@pid=$$(cat $(PID_DIR)/dm-mcp.pid); \
+	printf "  Waiting for /healthz"; \
+	for i in $$(seq 1 50); do \
+		if ! kill -0 "$$pid" 2>/dev/null; then \
 			echo ""; \
-			echo "✗ dm-mcp exited before /healthz came up. Last log lines:"; \
+			echo "✗ dm-mcp (pid $$pid) exited before /healthz came up. Last log lines:"; \
 			tail -n 20 $(LOG_DIR)/dm-mcp.log; \
 			rm -f $(PID_DIR)/dm-mcp.pid; \
 			exit 1; \
+		fi; \
+		if curl -sf http://$(HTTP_BIND):$(HTTP_PORT)/healthz > /dev/null 2>&1; then \
+			echo " ready"; \
+			echo "  pid: $$pid — log: $(LOG_DIR)/dm-mcp.log"; \
+			exit 0; \
 		fi; \
 		printf '.'; sleep 0.2; \
 	done; \
 	echo ""; \
 	echo "✗ Server did not come up within 10s. See $(LOG_DIR)/dm-mcp.log"; \
+	if kill -0 "$$pid" 2>/dev/null; then \
+		echo "  killing leftover process (pid $$pid)..."; \
+		kill "$$pid" 2>/dev/null || true; \
+		sleep 1; \
+		if kill -0 "$$pid" 2>/dev/null; then \
+			kill -9 "$$pid" 2>/dev/null || true; \
+		fi; \
+	fi; \
+	rm -f $(PID_DIR)/dm-mcp.pid; \
 	exit 1
 
 _service-stop: _sweep-stale

--- a/Makefile
+++ b/Makefile
@@ -245,10 +245,18 @@ _service-start: _sweep-stale
 _service-stop: _sweep-stale
 	@if [ -f "$(PID_DIR)/dm-mcp.pid" ]; then \
 		pid=$$(cat "$(PID_DIR)/dm-mcp.pid"); \
-		if kill -0 "$$pid" 2>/dev/null; then \
-			kill "$$pid" && echo "✓ Stopped dm-mcp (pid: $$pid)"; \
+		if [ -z "$$pid" ] || ! kill -0 "$$pid" 2>/dev/null; then \
+			rm -f "$(PID_DIR)/dm-mcp.pid"; \
+		else \
+			comm=$$(cat "/proc/$$pid/comm" 2>/dev/null || true); \
+			cwd=$$(readlink "/proc/$$pid/cwd" 2>/dev/null || true); \
+			if [ "$$comm" = "dm-mcp" ] && [ "$$cwd" = "$(CURDIR)" ]; then \
+				kill "$$pid" && echo "✓ Stopped dm-mcp (pid: $$pid)"; \
+			else \
+				echo "⚠ pid $$pid is not this checkout's dm-mcp (comm=$$comm cwd=$$cwd); not killing"; \
+			fi; \
+			rm -f "$(PID_DIR)/dm-mcp.pid"; \
 		fi; \
-		rm -f "$(PID_DIR)/dm-mcp.pid"; \
 	fi
 
 # Catch-all: kill any dm-mcp binary from THIS checkout left behind by an earlier

--- a/examples/manual_demo.rs
+++ b/examples/manual_demo.rs
@@ -55,9 +55,17 @@ async fn main() -> Result<()> {
         .with_writer(std::io::stderr)
         .try_init();
 
-    // Examples don't get `CARGO_BIN_EXE_<name>`, so locate the debug binary ourselves.
-    // `make demo` depends on `_build-debug`, which guarantees this path exists.
-    let bin_path = std::env::current_dir()?.join("target/debug/dm-mcp");
+    // Examples don't get `CARGO_BIN_EXE_<name>`, so locate the dm-mcp binary relative to
+    // where *this* example was built. current_exe() is target/<profile>/examples/manual_demo,
+    // so walking up twice lands in target/<profile>/ — which holds the sibling dm-mcp binary
+    // for the same profile. This honors CARGO_TARGET_DIR and works for both debug and release.
+    // `make demo` depends on `_build-debug`, which guarantees dm-mcp exists in that directory.
+    let current_exe = std::env::current_exe().context("locate manual_demo executable")?;
+    let profile_dir = current_exe
+        .parent()
+        .and_then(|examples_dir| examples_dir.parent())
+        .context("manual_demo should run from target/<profile>/examples")?;
+    let bin_path = profile_dir.join(format!("dm-mcp{}", std::env::consts::EXE_SUFFIX));
     if !bin_path.exists() {
         anyhow::bail!(
             "dm-mcp binary not found at {}.\n  \

--- a/examples/manual_demo.rs
+++ b/examples/manual_demo.rs
@@ -1,0 +1,137 @@
+//! Manual-test walkthrough for dm-mcp over stdio.
+//!
+//! Spawns the compiled binary as an MCP child process, completes the handshake, lists the
+//! registered tools, calls `server.info`, pretty-prints every response the client sees, and
+//! shuts the session down cleanly.
+//!
+//! This is the "see it respond to requests" counterpart to the automated integration tests
+//! in `tests/`. The same rmcp client library that a real DM agent uses is what drives this
+//! demo, so what prints here is exactly what an agent would receive on the wire.
+//!
+//! ## Run
+//!
+//! ```sh
+//! make demo
+//! ```
+//!
+//! Or manually:
+//!
+//! ```sh
+//! cargo build && cargo run --example manual_demo
+//! ```
+//!
+//! ## Seeing the wire traffic
+//!
+//! rmcp emits `trace`-level log events for every JSON-RPC frame it sends and receives.
+//! To see them, set `RUST_LOG`:
+//!
+//! ```sh
+//! RUST_LOG=rmcp=trace make demo
+//! ```
+//!
+//! Server-side logs write to stderr so they interleave visibly with the client-side output.
+
+use anyhow::{Context, Result};
+use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::transport::TokioChildProcess;
+use rmcp::ServiceExt;
+use tokio::process::Command;
+
+fn banner(n: u32, title: &str) {
+    println!();
+    println!("────────────────────────────────────────────────────────────");
+    println!(" {n}. {title}");
+    println!("────────────────────────────────────────────────────────────");
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Install a simple tracing subscriber so RUST_LOG=rmcp=trace shows wire frames on stderr.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+
+    // Examples don't get `CARGO_BIN_EXE_<name>`, so locate the debug binary ourselves.
+    // `make demo` depends on `_build-debug`, which guarantees this path exists.
+    let bin_path = std::env::current_dir()?.join("target/debug/dm-mcp");
+    if !bin_path.exists() {
+        anyhow::bail!(
+            "dm-mcp binary not found at {}.\n  \
+             Run `cargo build` first, or use `make demo` which builds + runs in one step.",
+            bin_path.display()
+        );
+    }
+
+    banner(1, "Spawning dm-mcp as an MCP stdio child process");
+    println!("  binary : {}", bin_path.display());
+    println!("  args   : stdio");
+    println!("  env    : DMMCP_LOG_LEVEL=warn");
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("stdio");
+    cmd.env("DMMCP_LOG_LEVEL", "warn");
+    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
+
+    banner(2, "Completing the MCP handshake (initialize → initialized)");
+    let client = ().serve(transport).await.context("mcp handshake")?;
+    let info = client
+        .peer_info()
+        .context("peer_info should be populated after handshake")?;
+    println!("  server name      : {}", info.server_info.name);
+    println!("  server version   : {}", info.server_info.version);
+    println!("  protocol version : {:?}", info.protocol_version);
+    if let Some(inst) = &info.instructions {
+        println!("  instructions     : {inst}");
+    }
+
+    banner(3, "Listing available tools (tools/list RPC)");
+    let tools = client.list_all_tools().await.context("list_all_tools")?;
+    if tools.is_empty() {
+        println!("  (no tools registered)");
+    } else {
+        for tool in &tools {
+            println!("  • {name}", name = tool.name,);
+            if let Some(desc) = tool.description.as_deref() {
+                println!("      {desc}");
+            }
+        }
+        println!();
+        println!("  {} total", tools.len());
+    }
+
+    banner(4, "Calling tool: server.info (tools/call RPC)");
+    let result = client
+        .call_tool(CallToolRequestParams::new("server.info"))
+        .await
+        .context("call_tool server.info")?;
+    println!("  is_error : {:?}", result.is_error);
+    if result.content.is_empty() {
+        println!("  content  : <empty>");
+    }
+    for item in &result.content {
+        match &item.raw {
+            RawContent::Text(t) => {
+                println!("  text     : {}", t.text);
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&t.text) {
+                    if let Some(obj) = v.as_object() {
+                        println!("  parsed   :");
+                        for (k, val) in obj {
+                            println!("    {k} = {val}");
+                        }
+                    }
+                }
+            }
+            other => println!("  non-text : {other:?}"),
+        }
+    }
+
+    banner(5, "Cancelling the session cleanly");
+    client.cancel().await.context("cancel client")?;
+    println!("  ✓ session closed");
+    println!();
+
+    Ok(())
+}

--- a/examples/manual_demo.rs
+++ b/examples/manual_demo.rs
@@ -107,7 +107,10 @@ async fn main() -> Result<()> {
         .call_tool(CallToolRequestParams::new("server.info"))
         .await
         .context("call_tool server.info")?;
-    println!("  is_error : {:?}", result.is_error);
+    // Per the MCP spec `is_error` is optional — `None` and `Some(false)` both mean
+    // "success", only `Some(true)` is an actual error. Collapse to a bool for display.
+    let is_error = result.is_error.unwrap_or(false);
+    println!("  is_error : {is_error}");
     if result.content.is_empty() {
         println!("  content  : <empty>");
     }


### PR DESCRIPTION
## Summary

Local development Makefile, modelled on the larderly Makefile provided by the user and adapted for dm-mcp's much simpler runtime — single binary, embedded SQLite, no Postgres / workspace / Playwright. Mirrors the two CI workflows (\`ci.yaml\`, \`commit.yaml\`) so \`make check\` / \`make audit\` run the same gates locally.

### User-facing targets

| Target | Effect |
|---|---|
| \`make dev\` | Build debug binary, start HTTP transport in the background, wait for \`/healthz\`, hand back control. |
| \`make run-stdio\` | Attach the stdio transport to this terminal. For piping MCP frames or spawning via a client. |
| \`make health\` | \`curl /healthz\` on the running dev server. |
| \`make logs\` | Tail \`.logs/dm-mcp.log\`. |
| \`make clean\` | Stop service + \`cargo clean\` + wipe \`.logs\` / \`.pids\`. |
| \`make reset\` | Stop service + delete \`campaign.db\` (+ WAL sidecars). Destructive — confirms wipe in the output. |
| \`make test\` | \`cargo test\` (unit + integration). |
| \`make check\` | \`fmt\` + \`clippy -D warnings\` + \`cargo tree -i openssl\|openssl-sys\|native-tls\` + \`cargo test\`. Matches \`.github/workflows/ci.yaml\`. |
| \`make audit\` | \`cargo audit\` + no-OpenSSL verification. Matches \`.github/workflows/commit.yaml\`. Installs \`cargo-audit\` on demand. |
| \`make build\` | Release build (target for the scratch container image). |

### Service lifecycle

PID written to \`.pids/dm-mcp.pid\`, stdout/stderr to \`.logs/dm-mcp.log\`. \`_sweep-stale\` catch-all uses \`pgrep -x dm-mcp\` filtered by \`/proc/<pid>/cwd == \$(CURDIR)\`, so only processes from THIS checkout are touched. SIGTERM → 1s wait → SIGKILL escalation for any holdouts. Silent on a clean box.

## Test plan

- [x] \`make _sweep-stale\` on a clean box — silent.
- [x] \`make _check-fmt\` — OK.
- [x] \`make _check-no-openssl\` — OK.
- [x] \`make dev\` — builds, spawns server, waits for \`/healthz\`, prints banner.
- [x] \`make health\` — returns \"ok\" then \"✓ /healthz OK\".
- [x] \`make _service-stop\` — sweeps the running process via SIGTERM.
- [x] Log captures \`SIGTERM received; starting graceful shutdown\` — confirms the Phase 1 SIGTERM fix fires end-to-end when invoked via \`make\`.

Not a CI-impacting change (Makefile-only; workflows unchanged). Safe to merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive Makefile providing developer and CI workflows for building, testing, quality assurance, and security audits
  * Updated .gitignore to exclude local development files, build artifacts, and database runtime files

* **Documentation**
  * Added example walkthrough demonstrating service startup, tool discovery, and invocation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->