### PR TITLE
Phase 2: DB schema + content loader + content.introspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "assert_cmd",
  "axum",
  "clap",
+ "include_dir",
  "reqwest",
  "rmcp",
  "rusqlite",
@@ -929,6 +930,25 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,9 +429,11 @@ dependencies = [
  "clap",
  "reqwest",
  "rmcp",
+ "rusqlite",
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -468,6 +470,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +498,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -635,7 +655,16 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -643,6 +672,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -1018,6 +1056,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1193,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1480,6 +1535,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1816,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1873,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2125,6 +2230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2281,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ anyhow = "1.0.102"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
 rmcp = { version = "1.5.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server", "schemars"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 schemars = "1.2.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_yaml_ng = "0.10.0"
 tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "io-std", "signal", "net", "sync", "process", "time"] }
 tokio-util = { version = "0.7.18", features = ["codec"] }
 tracing = "0.1.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 anyhow = "1.0.102"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
+include_dir = "0.7.4"
 rmcp = { version = "1.5.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server", "schemars"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 schemars = "1.2.1"

--- a/content/items/bases/weapons.yaml
+++ b/content/items/bases/weapons.yaml
@@ -1,0 +1,14 @@
+# One sample weapon base for Phase 2. The damage/weight/value fields align with
+# the 5.1 SRD's longsword entry; description is original. See docs/items.md and
+# docs/ip-and-licensing.md.
+
+weapons:
+  longsword:
+    name: Longsword
+    description: "A double-edged steel blade about three feet long. Versatile — can be wielded in one hand or two."
+    damage: 1d8
+    damage_type: slashing
+    weight_lb: 3
+    base_value_gp: 15
+    properties: [versatile]
+    slot: main-hand

--- a/content/items/enchantments.yaml
+++ b/content/items/enchantments.yaml
@@ -1,0 +1,8 @@
+# One sample enchantment for Phase 2. See docs/items.md §Enchantments.
+
+enchantments:
+  glowing:
+    kind: utility
+    description: "A faint inner light; sheds dim illumination out to about ten feet."
+    value_premium_gp: 50
+    weight_delta: 0

--- a/content/npcs/archetypes/village_elder.yaml
+++ b/content/npcs/archetypes/village_elder.yaml
@@ -1,0 +1,47 @@
+# One sample archetype for Phase 2. Note: no alignment axis — archetype
+# describes role + current faction, not species essence. See docs/npcs.md
+# §Non-violent resolution.
+
+id: village_elder
+species: human
+role_hint: friendly
+typical_age_years: [55, 80]
+
+stats:
+  str: [8, 11]
+  dex: [8, 11]
+  con: [10, 13]
+  int: [12, 16]
+  wis: [14, 18]
+  cha: [12, 16]
+
+hp_formula: "2d6 + con_mod*2"
+ac_base: 10
+speed_ft: 25
+
+proficiencies:
+  - { name: 'save:wis',    proficient: true }
+  - { name: insight,       proficient: true }
+  - { name: history,       proficient: true }
+  - { name: persuasion,    proficient: true }
+
+loadout:
+  - { base_kind: longsword, chance: 0.15, material: steel, material_tier: 1, notes: "Symbolic; rarely drawn" }
+
+plan_pool:
+  - "Preserve the village through another winter"
+  - "Find someone to pass stewardship to"
+  - "Reconcile an old feud before it's too late"
+
+ideology_pool:
+  - "The village is only the people in it; everything else can be rebuilt"
+  - "Tradition is load-bearing; change costs more than it saves"
+
+social:
+  can_parley: true
+  parley_requires: []
+
+backstory_hooks:
+  - "Served ${predecessor} as reeve before the old one passed"
+  - "Brokered peace with ${neighbouring_settlement} after ${past_conflict}"
+  - "Lost ${relation} to ${past_disaster}"

--- a/content/rules/abilities.yaml
+++ b/content/rules/abilities.yaml
@@ -1,0 +1,29 @@
+# The six d20-inspired ability scores. See docs/checks.md for how these feed
+# into the resolve_check pipeline. Mechanically aligns with the 5.1 SRD
+# (CC-BY-4.0) — the convention of six abilities is pre-WotC and not protectable,
+# but our descriptions are original. See docs/ip-and-licensing.md.
+
+abilities:
+  - id: str
+    name: Strength
+    governs: "Physical power, carrying capacity, melee damage"
+
+  - id: dex
+    name: Dexterity
+    governs: "Agility, reflexes, balance, ranged accuracy"
+
+  - id: con
+    name: Constitution
+    governs: "Endurance, hit points, resisting poison and exhaustion"
+
+  - id: int
+    name: Intelligence
+    governs: "Reasoning, memory, arcane study"
+
+  - id: wis
+    name: Wisdom
+    governs: "Perception, intuition, attunement to the world"
+
+  - id: cha
+    name: Charisma
+    governs: "Force of personality, social presence, negotiation"

--- a/content/rules/conditions.yaml
+++ b/content/rules/conditions.yaml
@@ -1,0 +1,97 @@
+# Named conditions with their mechanical riders. resolve_check reads these at
+# check time; see docs/checks.md §Conditions. Condition names are generic RPG
+# vocabulary; descriptions and rider details are original.
+
+conditions:
+  blinded:
+    description: "The affected creature cannot rely on sight."
+    self:
+      attack_rolls: disadvantage
+      sight_checks: auto_fail
+    against:
+      attack_rolls: advantage
+
+  charmed:
+    description: "Dominated emotionally by the charmer; cannot attack them or target them with harmful effects."
+    self:
+      cannot_target_charmer: true
+    against:
+      social_checks_from_charmer: advantage
+
+  deafened:
+    description: "The affected creature cannot hear."
+    self:
+      hearing_checks: auto_fail
+
+  frightened:
+    description: "Afraid of a specific source; penalised near it."
+    self:
+      attack_rolls_in_sight_of_source: disadvantage
+      ability_checks_in_sight_of_source: disadvantage
+      can_approach_source: false
+
+  paralyzed:
+    description: "Rigid and helpless; cannot move or act."
+    self:
+      can_move: false
+      can_act: false
+      auto_fail: [save:str, save:dex]
+    against:
+      attack_rolls: advantage
+      auto_crit_if_melee_within_5ft: true
+
+  poisoned:
+    description: "Acutely ill; all rolls are less reliable."
+    self:
+      attack_rolls: disadvantage
+      ability_checks: disadvantage
+
+  prone:
+    description: "On the ground; slow to rise and off-balance."
+    self:
+      attack_rolls: disadvantage
+      move_speed_multiplier: 0.5
+    against:
+      attack_rolls_within_5ft: advantage
+      attack_rolls_beyond_5ft: disadvantage
+
+  stunned:
+    description: "Dazed and unresponsive."
+    self:
+      can_act: false
+      can_move: false
+      auto_fail: [save:str, save:dex]
+    against:
+      attack_rolls: advantage
+
+  unconscious:
+    description: "Senseless and incapacitated. Typically entered at 0 HP — see mortally_wounded."
+    self:
+      can_act: false
+      can_move: false
+      auto_fail: [save:str, save:dex]
+      drops_held_items: true
+    against:
+      attack_rolls: advantage
+      auto_crit_if_melee_within_5ft: true
+
+  mortally_wounded:
+    description: "At 0 HP and dying. Three failed death saves → dead; three successes → stabilised."
+    self:
+      can_act: false
+      hp_floor: 0
+
+  encumbered:
+    description: "Carrying more than is comfortable; slowed."
+    self:
+      speed_penalty: -10
+
+  exhaustion:
+    description: "Progressive fatigue. Severity 1-6; each level adds a penalty."
+    severity_levels:
+      1: { disadvantage_on: [ability_checks] }
+      2: { speed_halved: true }
+      3: { disadvantage_on: [attack_rolls, saves] }
+      4: { hp_max_halved: true }
+      5: { speed_zero: true }
+      6: { death: true }

--- a/content/rules/damage_types.yaml
+++ b/content/rules/damage_types.yaml
@@ -1,0 +1,16 @@
+# Standard damage types. Generic across d20-style systems; descriptions original.
+
+damage_types:
+  - { id: bludgeoning, physical: true,  description: "Crushing force — hammers, falling rocks, cudgels" }
+  - { id: piercing,    physical: true,  description: "Puncturing strikes — arrows, spears, fangs" }
+  - { id: slashing,    physical: true,  description: "Cleaving blows — swords, claws, axes" }
+  - { id: acid,        physical: false, description: "Corrosive fluid or vapour" }
+  - { id: cold,        physical: false, description: "Freezing temperatures or icy strikes" }
+  - { id: fire,        physical: false, description: "Heat, flame, thermal shock" }
+  - { id: force,       physical: false, description: "Raw magical energy, unaligned with any element" }
+  - { id: lightning,   physical: false, description: "Electrical discharge" }
+  - { id: necrotic,    physical: false, description: "Decay, withering of vital essence" }
+  - { id: poison,      physical: false, description: "Biological or alchemical toxins" }
+  - { id: psychic,     physical: false, description: "Direct assault on the mind" }
+  - { id: radiant,     physical: false, description: "Searing light or holy energy" }
+  - { id: thunder,     physical: false, description: "Concussive sound" }

--- a/content/rules/skills.yaml
+++ b/content/rules/skills.yaml
@@ -1,0 +1,23 @@
+# Named skills and the ability each defaults to. Mechanically 5.1 SRD-aligned;
+# skill names are generic / descriptive, not WotC-owned branding. Descriptions
+# are original. See docs/ip-and-licensing.md.
+
+skills:
+  - { id: acrobatics,      ability: dex, description: "Keep your feet on narrow ledges; tumble or dive" }
+  - { id: animal_handling, ability: wis, description: "Calm, direct, or soothe beasts of limited intellect" }
+  - { id: arcana,          ability: int, description: "Recall arcane lore — spells, planes, artefacts" }
+  - { id: athletics,       ability: str, description: "Climb, swim, jump, grapple" }
+  - { id: deception,       ability: cha, description: "Convince someone a lie is the truth" }
+  - { id: history,         ability: int, description: "Recall the events of the past" }
+  - { id: insight,         ability: wis, description: "Read body language, guess intent" }
+  - { id: intimidation,    ability: cha, description: "Impose your will through threat or presence" }
+  - { id: investigation,   ability: int, description: "Work out how something fits together" }
+  - { id: medicine,        ability: wis, description: "Stabilise the dying, diagnose an ailment" }
+  - { id: nature,          ability: int, description: "Know plants, animals, terrain, weather" }
+  - { id: perception,      ability: wis, description: "Spot, hear, otherwise notice your surroundings" }
+  - { id: performance,     ability: cha, description: "Entertain a crowd — music, theatre, rhetoric" }
+  - { id: persuasion,      ability: cha, description: "Win hearts and minds through reasoned argument" }
+  - { id: religion,        ability: int, description: "Recall deities, holy orders, funerary rites" }
+  - { id: sleight_of_hand, ability: dex, description: "Pick a pocket; palm a coin; plant a thing" }
+  - { id: stealth,         ability: dex, description: "Move unseen, unheard" }
+  - { id: survival,        ability: wis, description: "Track, hunt, navigate wild places" }

--- a/content/world/biomes.yaml
+++ b/content/world/biomes.yaml
@@ -1,0 +1,11 @@
+# One sample biome for Phase 2. Later phases will add the full set. See
+# docs/world.md for the biome/zone model.
+
+biomes:
+  temperate_forest:
+    name: Temperate Forest
+    description: "Broadleaf woodland; dappled light and leaf-litter underfoot."
+    typical_kind: wilderness
+    typical_size_range: [small, large]
+    encounter_tags: [forest, wildlife, bandits_rare]
+    connection_count_range: [2, 4]

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,0 +1,361 @@
+//! Bundled YAML content loaded once at startup.
+//!
+//! Per the architectural principle: **content is data, not code**. Everything that describes
+//! *what a thing is* (ability definitions, conditions, archetypes, item base-kinds) lives
+//! under `content/` and ships inside the binary via `include_str!`. Only instance data lives
+//! in SQLite.
+//!
+//! See:
+//!   - `docs/content.md`           — directory layout and loading contract
+//!   - `docs/ip-and-licensing.md`  — licensing rules for content authoring
+//!
+//! `DMMCP_CONTENT_DIR` (if set) loads from disk instead of the embedded copy, for dev
+//! iteration or user customisation without rebuilding.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+// ── Embedded content ──────────────────────────────────────────────────────────
+//
+// Files are bundled at compile time. The paths are relative to this source file (Cargo
+// rewrites them to be relative to CARGO_MANIFEST_DIR when it applies the macro).
+
+const ABILITIES_YAML: &str = include_str!("../content/rules/abilities.yaml");
+const SKILLS_YAML: &str = include_str!("../content/rules/skills.yaml");
+const DAMAGE_TYPES_YAML: &str = include_str!("../content/rules/damage_types.yaml");
+const CONDITIONS_YAML: &str = include_str!("../content/rules/conditions.yaml");
+const BIOMES_YAML: &str = include_str!("../content/world/biomes.yaml");
+const WEAPONS_YAML: &str = include_str!("../content/items/bases/weapons.yaml");
+const ENCHANTMENTS_YAML: &str = include_str!("../content/items/enchantments.yaml");
+const VILLAGE_ELDER_YAML: &str = include_str!("../content/npcs/archetypes/village_elder.yaml");
+
+// ── Section wrappers ──────────────────────────────────────────────────────────
+//
+// Each YAML file has a single top-level key (e.g. `abilities:`). We deserialize into a
+// small wrapper type per file and then strip the envelope.
+
+#[derive(Debug, Deserialize)]
+struct AbilitiesFile {
+    abilities: Vec<Ability>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillsFile {
+    skills: Vec<Skill>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DamageTypesFile {
+    damage_types: Vec<DamageType>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConditionsFile {
+    // Conditions have heterogeneous per-condition payloads (self/against/severity_levels).
+    // Keep the shape raw here — Phase 2 only needs to enumerate the keys; later phases will
+    // parse rider details into typed structs.
+    conditions: BTreeMap<String, serde_yaml_ng::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BiomesFile {
+    biomes: BTreeMap<String, serde_yaml_ng::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WeaponsFile {
+    weapons: BTreeMap<String, serde_yaml_ng::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnchantmentsFile {
+    enchantments: BTreeMap<String, serde_yaml_ng::Value>,
+}
+
+// ── Public content types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ability {
+    pub id: String,
+    pub name: String,
+    pub governs: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Skill {
+    pub id: String,
+    pub ability: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DamageType {
+    pub id: String,
+    pub physical: bool,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Archetype {
+    pub id: String,
+    pub species: String,
+    pub role_hint: String,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+}
+
+/// Parsed content, ready for tool lookups. Held in an `Arc` and shared across MCP sessions.
+#[derive(Debug)]
+pub struct Content {
+    pub abilities: Vec<Ability>,
+    pub skills: Vec<Skill>,
+    pub damage_types: Vec<DamageType>,
+    pub conditions: BTreeMap<String, serde_yaml_ng::Value>,
+    pub biomes: BTreeMap<String, serde_yaml_ng::Value>,
+    pub weapons: BTreeMap<String, serde_yaml_ng::Value>,
+    pub enchantments: BTreeMap<String, serde_yaml_ng::Value>,
+    pub archetypes: BTreeMap<String, Archetype>,
+}
+
+impl Content {
+    /// Load content. If `override_dir` is `Some`, read every file from that directory
+    /// (expecting the same sub-layout as `content/`). Otherwise use the embedded copies.
+    pub fn load(override_dir: Option<&Path>) -> Result<Self> {
+        match override_dir {
+            Some(dir) => Self::load_from_dir(dir),
+            None => Self::load_embedded(),
+        }
+    }
+
+    fn load_embedded() -> Result<Self> {
+        let abilities: AbilitiesFile = parse(ABILITIES_YAML, "rules/abilities.yaml (embedded)")?;
+        let skills: SkillsFile = parse(SKILLS_YAML, "rules/skills.yaml (embedded)")?;
+        let damage_types: DamageTypesFile =
+            parse(DAMAGE_TYPES_YAML, "rules/damage_types.yaml (embedded)")?;
+        let conditions: ConditionsFile =
+            parse(CONDITIONS_YAML, "rules/conditions.yaml (embedded)")?;
+        let biomes: BiomesFile = parse(BIOMES_YAML, "world/biomes.yaml (embedded)")?;
+        let weapons: WeaponsFile = parse(WEAPONS_YAML, "items/bases/weapons.yaml (embedded)")?;
+        let enchantments: EnchantmentsFile =
+            parse(ENCHANTMENTS_YAML, "items/enchantments.yaml (embedded)")?;
+
+        let mut archetypes = BTreeMap::new();
+        archetypes.insert(
+            "village_elder".to_string(),
+            parse::<Archetype>(
+                VILLAGE_ELDER_YAML,
+                "npcs/archetypes/village_elder.yaml (embedded)",
+            )?,
+        );
+
+        Self::assemble(
+            abilities.abilities,
+            skills.skills,
+            damage_types.damage_types,
+            conditions.conditions,
+            biomes.biomes,
+            weapons.weapons,
+            enchantments.enchantments,
+            archetypes,
+        )
+    }
+
+    fn load_from_dir(dir: &Path) -> Result<Self> {
+        let abilities: AbilitiesFile = parse_file(&dir.join("rules/abilities.yaml"))?;
+        let skills: SkillsFile = parse_file(&dir.join("rules/skills.yaml"))?;
+        let damage_types: DamageTypesFile = parse_file(&dir.join("rules/damage_types.yaml"))?;
+        let conditions: ConditionsFile = parse_file(&dir.join("rules/conditions.yaml"))?;
+        let biomes: BiomesFile = parse_file(&dir.join("world/biomes.yaml"))?;
+        let weapons: WeaponsFile = parse_file(&dir.join("items/bases/weapons.yaml"))?;
+        let enchantments: EnchantmentsFile = parse_file(&dir.join("items/enchantments.yaml"))?;
+
+        let mut archetypes = BTreeMap::new();
+        let archetype_dir = dir.join("npcs/archetypes");
+        if archetype_dir.is_dir() {
+            for entry in std::fs::read_dir(&archetype_dir)
+                .with_context(|| format!("read archetype dir {}", archetype_dir.display()))?
+            {
+                let entry = entry?;
+                let p = entry.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("yaml") {
+                    let a: Archetype = parse_file(&p)?;
+                    archetypes.insert(a.id.clone(), a);
+                }
+            }
+        }
+
+        Self::assemble(
+            abilities.abilities,
+            skills.skills,
+            damage_types.damage_types,
+            conditions.conditions,
+            biomes.biomes,
+            weapons.weapons,
+            enchantments.enchantments,
+            archetypes,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assemble(
+        abilities: Vec<Ability>,
+        skills: Vec<Skill>,
+        damage_types: Vec<DamageType>,
+        conditions: BTreeMap<String, serde_yaml_ng::Value>,
+        biomes: BTreeMap<String, serde_yaml_ng::Value>,
+        weapons: BTreeMap<String, serde_yaml_ng::Value>,
+        enchantments: BTreeMap<String, serde_yaml_ng::Value>,
+        archetypes: BTreeMap<String, Archetype>,
+    ) -> Result<Self> {
+        let content = Self {
+            abilities,
+            skills,
+            damage_types,
+            conditions,
+            biomes,
+            weapons,
+            enchantments,
+            archetypes,
+        };
+        content.validate()?;
+        Ok(content)
+    }
+
+    /// Cross-section invariants: every skill's `ability` key must match a real ability id.
+    /// Future phases will add more checks (archetype proficiencies reference real skills, etc.).
+    fn validate(&self) -> Result<()> {
+        let ability_ids: std::collections::HashSet<&str> =
+            self.abilities.iter().map(|a| a.id.as_str()).collect();
+        for s in &self.skills {
+            if !ability_ids.contains(s.ability.as_str()) {
+                anyhow::bail!(
+                    "skill {:?} references unknown ability {:?}; valid abilities: {:?}",
+                    s.id,
+                    s.ability,
+                    ability_ids
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Summary for the `content.introspect` MCP tool. One map per section with its IDs —
+    /// small, deterministic, easy for the agent to diff across runs.
+    pub fn introspect(&self) -> Introspection {
+        Introspection {
+            abilities: self.abilities.iter().map(|a| a.id.clone()).collect(),
+            skills: self.skills.iter().map(|s| s.id.clone()).collect(),
+            damage_types: self.damage_types.iter().map(|d| d.id.clone()).collect(),
+            conditions: self.conditions.keys().cloned().collect(),
+            biomes: self.biomes.keys().cloned().collect(),
+            weapons: self.weapons.keys().cloned().collect(),
+            enchantments: self.enchantments.keys().cloned().collect(),
+            archetypes: self.archetypes.keys().cloned().collect(),
+        }
+    }
+}
+
+/// Structured summary returned by `content.introspect`. JSON-serialisable so the handler
+/// can ship it straight to the MCP client.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Introspection {
+    pub abilities: Vec<String>,
+    pub skills: Vec<String>,
+    pub damage_types: Vec<String>,
+    pub conditions: Vec<String>,
+    pub biomes: Vec<String>,
+    pub weapons: Vec<String>,
+    pub enchantments: Vec<String>,
+    pub archetypes: Vec<String>,
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+fn parse<T: for<'de> Deserialize<'de>>(source: &str, label: &str) -> Result<T> {
+    serde_yaml_ng::from_str(source).with_context(|| format!("parse {label}"))
+}
+
+fn parse_file<T: for<'de> Deserialize<'de>>(path: &PathBuf) -> Result<T> {
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    serde_yaml_ng::from_str(&source).with_context(|| format!("parse {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_content_loads_and_validates() {
+        let c = Content::load(None).expect("embedded content should parse");
+        assert_eq!(c.abilities.len(), 6, "six ability scores expected");
+        assert_eq!(c.skills.len(), 18, "18 skills expected");
+        assert!(
+            c.damage_types.iter().any(|d| d.id == "fire"),
+            "fire damage type should be present"
+        );
+        assert!(c.conditions.contains_key("blinded"));
+        assert!(c.weapons.contains_key("longsword"));
+        assert!(c.enchantments.contains_key("glowing"));
+        assert!(c.biomes.contains_key("temperate_forest"));
+        assert!(c.archetypes.contains_key("village_elder"));
+    }
+
+    #[test]
+    fn introspection_returns_every_section() {
+        let c = Content::load(None).expect("load");
+        let s = c.introspect();
+        assert!(s.abilities.contains(&"str".to_string()));
+        assert!(s.skills.contains(&"stealth".to_string()));
+        assert!(s.damage_types.contains(&"necrotic".to_string()));
+        assert!(s.conditions.contains(&"paralyzed".to_string()));
+        assert!(s.weapons.contains(&"longsword".to_string()));
+        assert!(s.enchantments.contains(&"glowing".to_string()));
+        assert!(s.biomes.contains(&"temperate_forest".to_string()));
+        assert!(s.archetypes.contains(&"village_elder".to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_skill_with_unknown_ability() {
+        // Build a Content by hand with a bogus skill reference.
+        let content = Content {
+            abilities: vec![Ability {
+                id: "str".into(),
+                name: "Strength".into(),
+                governs: "...".into(),
+            }],
+            skills: vec![Skill {
+                id: "bogus".into(),
+                ability: "xyz".into(), // <- not a real ability id
+                description: "...".into(),
+            }],
+            damage_types: vec![],
+            conditions: BTreeMap::new(),
+            biomes: BTreeMap::new(),
+            weapons: BTreeMap::new(),
+            enchantments: BTreeMap::new(),
+            archetypes: BTreeMap::new(),
+        };
+        let err = content
+            .validate()
+            .expect_err("should reject unknown ability");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown ability"),
+            "error should name the broken invariant: {msg}"
+        );
+    }
+
+    #[test]
+    fn dir_override_reads_yaml_from_disk() {
+        // Use the real content/ directory as the override — should match the embedded copy.
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let content_dir = repo_root.join("content");
+        let c = Content::load(Some(&content_dir)).expect("load from content/");
+        assert_eq!(c.abilities.len(), 6);
+        assert!(c.archetypes.contains_key("village_elder"));
+    }
+}

--- a/src/content.rs
+++ b/src/content.rs
@@ -2,7 +2,7 @@
 //!
 //! Per the architectural principle: **content is data, not code**. Everything that describes
 //! *what a thing is* (ability definitions, conditions, archetypes, item base-kinds) lives
-//! under `content/` and ships inside the binary via `include_str!`. Only instance data lives
+//! under `content/` and ships inside the binary via `include_dir!`. Only instance data lives
 //! in SQLite.
 //!
 //! See:
@@ -11,26 +11,33 @@
 //!
 //! `DMMCP_CONTENT_DIR` (if set) loads from disk instead of the embedded copy, for dev
 //! iteration or user customisation without rebuilding.
+//!
+//! ### Embedded vs on-disk path symmetry
+//!
+//! Both loading paths enumerate files from the same relative layout (`rules/abilities.yaml`,
+//! `npcs/archetypes/*.yaml`, etc.). The embedded path reads from a compile-time `Dir` tree
+//! built by [`include_dir!`]; the on-disk path walks the filesystem. A new YAML under
+//! `content/npcs/archetypes/` is picked up by both paths automatically — there's no manual
+//! `include_str!` list to keep in sync.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
+use include_dir::{include_dir, Dir};
 use serde::{Deserialize, Serialize};
 
-// ── Embedded content ──────────────────────────────────────────────────────────
-//
-// Files are bundled at compile time. The paths are relative to this source file (Cargo
-// rewrites them to be relative to CARGO_MANIFEST_DIR when it applies the macro).
+/// Compile-time snapshot of `content/`. Paths inside are relative to the directory root
+/// (e.g. `rules/abilities.yaml`, `npcs/archetypes/village_elder.yaml`).
+static CONTENT_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/content");
 
-const ABILITIES_YAML: &str = include_str!("../content/rules/abilities.yaml");
-const SKILLS_YAML: &str = include_str!("../content/rules/skills.yaml");
-const DAMAGE_TYPES_YAML: &str = include_str!("../content/rules/damage_types.yaml");
-const CONDITIONS_YAML: &str = include_str!("../content/rules/conditions.yaml");
-const BIOMES_YAML: &str = include_str!("../content/world/biomes.yaml");
-const WEAPONS_YAML: &str = include_str!("../content/items/bases/weapons.yaml");
-const ENCHANTMENTS_YAML: &str = include_str!("../content/items/enchantments.yaml");
-const VILLAGE_ELDER_YAML: &str = include_str!("../content/npcs/archetypes/village_elder.yaml");
+/// File extension is `.yaml` or `.yml`, case-insensitive.
+fn is_yaml_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some(ext) if ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml")
+    )
+}
 
 // ── Section wrappers ──────────────────────────────────────────────────────────
 //
@@ -120,71 +127,48 @@ pub struct Content {
     pub archetypes: BTreeMap<String, Archetype>,
 }
 
+/// Source of a single YAML file's bytes. Hides the difference between embedded (`&'static
+/// str`) and on-disk (`String`) so the parsing code is shared.
+enum YamlSource<'a> {
+    Embedded { path: &'a str, source: &'a str },
+    OnDisk { path: String, source: String },
+}
+
+impl YamlSource<'_> {
+    fn label(&self) -> String {
+        match self {
+            YamlSource::Embedded { path, .. } => format!("{path} (embedded)"),
+            YamlSource::OnDisk { path, .. } => path.clone(),
+        }
+    }
+    fn text(&self) -> &str {
+        match self {
+            YamlSource::Embedded { source, .. } => source,
+            YamlSource::OnDisk { source, .. } => source,
+        }
+    }
+}
+
 impl Content {
     /// Load content. If `override_dir` is `Some`, read every file from that directory
     /// (expecting the same sub-layout as `content/`). Otherwise use the embedded copies.
     pub fn load(override_dir: Option<&Path>) -> Result<Self> {
-        match override_dir {
-            Some(dir) => Self::load_from_dir(dir),
-            None => Self::load_embedded(),
-        }
-    }
+        let abilities: AbilitiesFile = parse(&get(override_dir, "rules/abilities.yaml")?)?;
+        let skills: SkillsFile = parse(&get(override_dir, "rules/skills.yaml")?)?;
+        let damage_types: DamageTypesFile = parse(&get(override_dir, "rules/damage_types.yaml")?)?;
+        let conditions: ConditionsFile = parse(&get(override_dir, "rules/conditions.yaml")?)?;
+        let biomes: BiomesFile = parse(&get(override_dir, "world/biomes.yaml")?)?;
+        let weapons: WeaponsFile = parse(&get(override_dir, "items/bases/weapons.yaml")?)?;
+        let enchantments: EnchantmentsFile = parse(&get(override_dir, "items/enchantments.yaml")?)?;
 
-    fn load_embedded() -> Result<Self> {
-        let abilities: AbilitiesFile = parse(ABILITIES_YAML, "rules/abilities.yaml (embedded)")?;
-        let skills: SkillsFile = parse(SKILLS_YAML, "rules/skills.yaml (embedded)")?;
-        let damage_types: DamageTypesFile =
-            parse(DAMAGE_TYPES_YAML, "rules/damage_types.yaml (embedded)")?;
-        let conditions: ConditionsFile =
-            parse(CONDITIONS_YAML, "rules/conditions.yaml (embedded)")?;
-        let biomes: BiomesFile = parse(BIOMES_YAML, "world/biomes.yaml (embedded)")?;
-        let weapons: WeaponsFile = parse(WEAPONS_YAML, "items/bases/weapons.yaml (embedded)")?;
-        let enchantments: EnchantmentsFile =
-            parse(ENCHANTMENTS_YAML, "items/enchantments.yaml (embedded)")?;
-
+        // Archetypes: discover every *.yaml / *.yml under npcs/archetypes/ in whichever
+        // source we're using. Embedded and on-disk use the same iteration logic so a new
+        // archetype file is picked up by both paths automatically.
         let mut archetypes = BTreeMap::new();
-        archetypes.insert(
-            "village_elder".to_string(),
-            parse::<Archetype>(
-                VILLAGE_ELDER_YAML,
-                "npcs/archetypes/village_elder.yaml (embedded)",
-            )?,
-        );
-
-        Self::assemble(
-            abilities.abilities,
-            skills.skills,
-            damage_types.damage_types,
-            conditions.conditions,
-            biomes.biomes,
-            weapons.weapons,
-            enchantments.enchantments,
-            archetypes,
-        )
-    }
-
-    fn load_from_dir(dir: &Path) -> Result<Self> {
-        let abilities: AbilitiesFile = parse_file(&dir.join("rules/abilities.yaml"))?;
-        let skills: SkillsFile = parse_file(&dir.join("rules/skills.yaml"))?;
-        let damage_types: DamageTypesFile = parse_file(&dir.join("rules/damage_types.yaml"))?;
-        let conditions: ConditionsFile = parse_file(&dir.join("rules/conditions.yaml"))?;
-        let biomes: BiomesFile = parse_file(&dir.join("world/biomes.yaml"))?;
-        let weapons: WeaponsFile = parse_file(&dir.join("items/bases/weapons.yaml"))?;
-        let enchantments: EnchantmentsFile = parse_file(&dir.join("items/enchantments.yaml"))?;
-
-        let mut archetypes = BTreeMap::new();
-        let archetype_dir = dir.join("npcs/archetypes");
-        if archetype_dir.is_dir() {
-            for entry in std::fs::read_dir(&archetype_dir)
-                .with_context(|| format!("read archetype dir {}", archetype_dir.display()))?
-            {
-                let entry = entry?;
-                let p = entry.path();
-                if p.extension().and_then(|e| e.to_str()) == Some("yaml") {
-                    let a: Archetype = parse_file(&p)?;
-                    archetypes.insert(a.id.clone(), a);
-                }
-            }
+        let archetype_sources = list_archetype_files(override_dir)?;
+        for src in &archetype_sources {
+            let a: Archetype = parse(src)?;
+            archetypes.insert(a.id.clone(), a);
         }
 
         Self::assemble(
@@ -272,16 +256,91 @@ pub struct Introspection {
     pub archetypes: Vec<String>,
 }
 
-// ── Parse helpers ─────────────────────────────────────────────────────────────
+// ── Source lookup ─────────────────────────────────────────────────────────────
 
-fn parse<T: for<'de> Deserialize<'de>>(source: &str, label: &str) -> Result<T> {
-    serde_yaml_ng::from_str(source).with_context(|| format!("parse {label}"))
+/// Fetch a YAML file by its relative path, from the override dir if set, else the embedded
+/// bundle. Fails with a clear error if the file is missing.
+fn get<'a>(override_dir: Option<&Path>, rel: &'a str) -> Result<YamlSource<'a>> {
+    match override_dir {
+        Some(dir) => {
+            let abs = dir.join(rel);
+            let source =
+                std::fs::read_to_string(&abs).with_context(|| format!("read {}", abs.display()))?;
+            Ok(YamlSource::OnDisk {
+                path: abs.display().to_string(),
+                source,
+            })
+        }
+        None => {
+            let file = CONTENT_DIR
+                .get_file(rel)
+                .with_context(|| format!("embedded content missing: {rel}"))?;
+            let source = file
+                .contents_utf8()
+                .with_context(|| format!("embedded {rel} is not UTF-8"))?;
+            Ok(YamlSource::Embedded { path: rel, source })
+        }
+    }
 }
 
-fn parse_file<T: for<'de> Deserialize<'de>>(path: &PathBuf) -> Result<T> {
-    let source =
-        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    serde_yaml_ng::from_str(&source).with_context(|| format!("parse {}", path.display()))
+/// Enumerate every `*.yaml` / `*.yml` under `npcs/archetypes/` in whichever source is active.
+fn list_archetype_files<'a>(override_dir: Option<&Path>) -> Result<Vec<YamlSource<'a>>> {
+    let mut out = Vec::new();
+    match override_dir {
+        Some(dir) => {
+            let archetype_dir = dir.join("npcs/archetypes");
+            if archetype_dir.is_dir() {
+                for entry in std::fs::read_dir(&archetype_dir)
+                    .with_context(|| format!("read archetype dir {}", archetype_dir.display()))?
+                {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if is_yaml_file(&path) {
+                        let source = std::fs::read_to_string(&path)
+                            .with_context(|| format!("read {}", path.display()))?;
+                        out.push(YamlSource::OnDisk {
+                            path: path.display().to_string(),
+                            source,
+                        });
+                    }
+                }
+            }
+        }
+        None => {
+            let archetype_dir = CONTENT_DIR
+                .get_dir("npcs/archetypes")
+                .context("embedded content missing npcs/archetypes/")?;
+            // We deliberately iterate `files()` (non-recursive) rather than `find("*.yaml")`
+            // so the list tracks the on-disk walker exactly.
+            for file in archetype_dir.files() {
+                let path = file.path();
+                if is_yaml_file(path) {
+                    let source = file
+                        .contents_utf8()
+                        .with_context(|| format!("embedded {} is not UTF-8", path.display()))?;
+                    // include_dir owns the &str for &'static program lifetime; we can keep
+                    // a static reference to the path too.
+                    out.push(YamlSource::Embedded {
+                        path: static_path_str(path),
+                        source,
+                    });
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Leak a Path's string into a `'static` slice via Box::leak. Only called once per embedded
+/// archetype file at startup — fine for a bounded, small content set.
+fn static_path_str(p: &Path) -> &'static str {
+    Box::leak(p.display().to_string().into_boxed_str())
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+fn parse<T: for<'de> Deserialize<'de>>(src: &YamlSource<'_>) -> Result<T> {
+    serde_yaml_ng::from_str(src.text()).with_context(|| format!("parse {}", src.label()))
 }
 
 #[cfg(test)]
@@ -351,11 +410,63 @@ mod tests {
 
     #[test]
     fn dir_override_reads_yaml_from_disk() {
-        // Use the real content/ directory as the override — should match the embedded copy.
         let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let content_dir = repo_root.join("content");
         let c = Content::load(Some(&content_dir)).expect("load from content/");
         assert_eq!(c.abilities.len(), 6);
+        assert!(c.archetypes.contains_key("village_elder"));
+    }
+
+    #[test]
+    fn yml_extension_is_also_accepted() {
+        // Sanity-check the extension matcher without manipulating the real fixtures.
+        assert!(is_yaml_file(Path::new("foo.yaml")));
+        assert!(is_yaml_file(Path::new("foo.yml")));
+        assert!(is_yaml_file(Path::new("FOO.YAML")));
+        assert!(is_yaml_file(Path::new("bar.YML")));
+        assert!(!is_yaml_file(Path::new("foo.json")));
+        assert!(!is_yaml_file(Path::new("foo.txt")));
+        assert!(!is_yaml_file(Path::new("foo")));
+    }
+
+    #[test]
+    fn override_dir_picks_up_extra_archetype_that_embedded_does_not() {
+        // Build a tmp dir that mirrors the real content/, drop in a second archetype, and
+        // verify Content::load(Some(&tmp)) discovers it. This is the regression guard
+        // against silent embedded/on-disk divergence (CodeRabbit PR #5 review).
+        use std::fs;
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let real_content = repo_root.join("content");
+        let tmp = tempfile::TempDir::new().expect("tmpdir");
+
+        fn copy_dir(src: &Path, dst: &Path) {
+            fs::create_dir_all(dst).unwrap();
+            for entry in fs::read_dir(src).unwrap() {
+                let entry = entry.unwrap();
+                let ft = entry.file_type().unwrap();
+                let from = entry.path();
+                let to = dst.join(entry.file_name());
+                if ft.is_dir() {
+                    copy_dir(&from, &to);
+                } else if ft.is_file() {
+                    fs::copy(&from, &to).unwrap();
+                }
+            }
+        }
+        copy_dir(&real_content, tmp.path());
+
+        let extra = tmp.path().join("npcs/archetypes/test_bandit.yaml");
+        fs::write(
+            &extra,
+            "id: test_bandit\nspecies: human\nrole_hint: enemy\n",
+        )
+        .unwrap();
+
+        let c = Content::load(Some(tmp.path())).expect("load from override");
+        assert!(
+            c.archetypes.contains_key("test_bandit"),
+            "override-dir path should auto-discover new archetype YAML files"
+        );
         assert!(c.archetypes.contains_key("village_elder"));
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,125 @@
+//! Campaign database: SQLite connection opener (PRAGMAs applied per docs/architecture.md)
+//! and schema migration.
+//!
+//! The MCP runs one campaign per process, so there's one DB connection for the process
+//! lifetime. Callers obtain a `Database` handle at startup and share it via `Arc`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+use crate::config::DbConfig;
+
+pub mod schema;
+
+/// Wrapper around a single SQLite connection. Phase 2 holds the connection directly; when
+/// we need concurrent access we'll add a mutex or switch to a pool.
+pub struct Database {
+    connection: Connection,
+}
+
+impl Database {
+    /// Open the campaign database at `cfg.path`, apply every PRAGMA from `cfg`, and run
+    /// migrations. Creates the file if it doesn't exist.
+    pub fn open(cfg: &DbConfig) -> Result<Self> {
+        let conn = open_connection(&cfg.path, cfg)
+            .with_context(|| format!("failed to open SQLite DB at {}", cfg.path.display()))?;
+        let mut db = Self { connection: conn };
+        schema::migrate(&mut db.connection).context("apply schema migrations")?;
+        Ok(db)
+    }
+
+    /// Borrow the underlying connection.
+    #[allow(dead_code)] // consumed by tools in Phase 3+
+    pub fn conn(&self) -> &Connection {
+        &self.connection
+    }
+}
+
+fn open_connection(path: &Path, cfg: &DbConfig) -> Result<Connection> {
+    let conn = Connection::open(path).context("rusqlite open")?;
+    apply_pragmas(&conn, cfg).context("apply PRAGMAs")?;
+    Ok(conn)
+}
+
+/// Set the tuning PRAGMAs. `foreign_keys=ON` is hard-coded (correctness, not tuning);
+/// everything else reads from `DbConfig` so operators can override via env vars.
+fn apply_pragmas(conn: &Connection, cfg: &DbConfig) -> Result<()> {
+    // These string values have already been validated by Config::from_env — they cannot
+    // be arbitrary user input at this point.
+    conn.execute_batch(&format!(
+        "PRAGMA journal_mode = {jm};
+         PRAGMA synchronous  = {sy};
+         PRAGMA mmap_size    = {mm};
+         PRAGMA cache_size   = {cs};
+         PRAGMA foreign_keys = ON;
+         PRAGMA temp_store   = MEMORY;",
+        jm = cfg.journal_mode,
+        sy = cfg.synchronous,
+        mm = cfg.mmap_size,
+        cs = cfg.cache_size,
+    ))
+    .context("PRAGMA batch")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn test_cfg(path: PathBuf) -> DbConfig {
+        DbConfig {
+            path,
+            journal_mode: "WAL".into(),
+            synchronous: "NORMAL".into(),
+            mmap_size: 1024 * 1024,
+            cache_size: -1024,
+        }
+    }
+
+    #[test]
+    fn open_creates_file_and_schema() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let db_path = tmp.path().join("test.db");
+        assert!(!db_path.exists(), "db file should not exist yet");
+
+        let _db = Database::open(&test_cfg(db_path.clone())).expect("open");
+        assert!(db_path.exists(), "db file should be created on open");
+    }
+
+    #[test]
+    fn reopen_is_idempotent() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let db_path = tmp.path().join("reopen.db");
+        {
+            let _first = Database::open(&test_cfg(db_path.clone())).expect("first open");
+        }
+        let _second = Database::open(&test_cfg(db_path.clone())).expect("second open");
+        assert!(db_path.exists());
+    }
+
+    #[test]
+    fn pragmas_are_applied() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let db_path = tmp.path().join("pragma.db");
+        let db = Database::open(&test_cfg(db_path)).expect("open");
+
+        let journal: String = db
+            .conn()
+            .query_row("PRAGMA journal_mode", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(journal.to_ascii_uppercase(), "WAL");
+
+        let fk: i64 = db
+            .conn()
+            .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            fk, 1,
+            "foreign_keys should be ON (hard-coded for correctness)"
+        );
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,0 +1,535 @@
+//! Campaign database schema — every table from `docs/`, created in one migration at startup.
+//!
+//! See the per-area docs for the field-level rationale:
+//!   - `docs/history-log.md`   — events, event_participants, event_items, two-tier time
+//!   - `docs/characters.md`    — characters, parties, character_resources, death flow
+//!   - `docs/checks.md`        — character_proficiencies, effects, character_conditions
+//!   - `docs/items.md`         — items, item_enchantments, location-mutex CHECK
+//!   - `docs/world.md`         — zones, zone_connections, landmarks, knowledge tables
+//!   - `docs/encounters.md`    — encounters, encounter_participants, combat fields inline
+//!   - `docs/campaign-setup.md`— campaign_state (singleton), campaign_setup_answers
+//!
+//! Future phases will extend this module with migration-history tracking when the schema
+//! starts evolving across released versions. Phase 2 is a greenfield create-all-tables pass.
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+/// Every table that Phase 2 creates. Kept here so tests can assert coverage without
+/// duplicating the list. Not yet consumed outside tests — later phases will reuse it for
+/// introspection / migration-history tooling.
+#[allow(dead_code)]
+pub const EXPECTED_TABLES: &[&str] = &[
+    // Entities
+    "parties",
+    "characters",
+    "character_proficiencies",
+    "character_resources",
+    "character_conditions",
+    "effects",
+    // Items
+    "items",
+    "item_enchantments",
+    // World
+    "zones",
+    "zone_connections",
+    "landmarks",
+    "character_zone_knowledge",
+    "character_landmark_knowledge",
+    // Encounters + combat
+    "encounters",
+    "encounter_participants",
+    // History
+    "events",
+    "event_participants",
+    "event_items",
+    // Campaign lifecycle
+    "campaign_state",
+    "campaign_setup_answers",
+];
+
+/// Create every table and index in a single transaction. Idempotent: re-running on a DB that
+/// already has the schema is a no-op because every CREATE uses IF NOT EXISTS.
+pub fn migrate(conn: &mut Connection) -> Result<()> {
+    let tx = conn.transaction().context("begin migration tx")?;
+    tx.execute_batch(DDL).context("apply schema DDL")?;
+    tx.commit().context("commit migration tx")?;
+    Ok(())
+}
+
+/// All CREATE TABLE + CREATE INDEX statements. Kept as one string so the migration is one
+/// `execute_batch` call in one transaction — atomic schema creation.
+const DDL: &str = r#"
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Parties: pure grouping, no stats or shared inventory. docs/characters.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS parties (
+    id           INTEGER PRIMARY KEY,
+    name         TEXT,
+    created_at   INTEGER NOT NULL    -- campaign_hour
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Characters: player, companions, pets, friendly NPCs, enemies — one table.
+-- Ability scores are BASE values; effective values compose with `effects` at read.
+-- docs/characters.md + docs/checks.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS characters (
+    id                      INTEGER PRIMARY KEY,
+    name                    TEXT NOT NULL,
+    role                    TEXT NOT NULL CHECK (role IN
+                              ('player', 'companion', 'friendly', 'enemy', 'neutral')),
+    party_id                INTEGER REFERENCES parties(id),
+
+    -- Six ability scores (base)
+    str_score               INTEGER NOT NULL,
+    dex_score               INTEGER NOT NULL,
+    con_score               INTEGER NOT NULL,
+    int_score               INTEGER NOT NULL,
+    wis_score               INTEGER NOT NULL,
+    cha_score               INTEGER NOT NULL,
+
+    -- Combat numbers
+    hp_current              INTEGER NOT NULL,
+    hp_max                  INTEGER NOT NULL,
+    hp_temp                 INTEGER NOT NULL DEFAULT 0,
+    armor_class             INTEGER NOT NULL,
+    speed_ft                INTEGER NOT NULL DEFAULT 30,
+    initiative_bonus        INTEGER NOT NULL DEFAULT 0,
+
+    -- Progression (denormalised from event log for read latency)
+    level                   INTEGER NOT NULL DEFAULT 1,
+    xp_total                INTEGER NOT NULL DEFAULT 0,
+    proficiency_bonus       INTEGER NOT NULL DEFAULT 2,
+
+    -- Physical
+    size                    TEXT NOT NULL DEFAULT 'medium'
+                              CHECK (size IN ('tiny','small','medium','large','huge','gargantuan')),
+
+    -- Narrative labels (LLM-interpreted)
+    species                 TEXT,
+    class_or_archetype      TEXT,
+    ideology                TEXT,
+    backstory               TEXT,
+    plans                   TEXT,
+
+    -- Party mechanics
+    loyalty                 INTEGER NOT NULL DEFAULT 50
+                              CHECK (loyalty BETWEEN 0 AND 100),
+
+    -- Lifecycle
+    status                  TEXT NOT NULL DEFAULT 'alive'
+                              CHECK (status IN ('alive','unconscious','dead','missing')),
+    current_zone_id         INTEGER,   -- FK resolved after zones created; SQLite resolves lazily
+    death_save_successes    INTEGER NOT NULL DEFAULT 0
+                              CHECK (death_save_successes BETWEEN 0 AND 3),
+    death_save_failures     INTEGER NOT NULL DEFAULT 0
+                              CHECK (death_save_failures BETWEEN 0 AND 3),
+
+    created_at              INTEGER NOT NULL,    -- campaign_hour
+    updated_at              INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_characters_role          ON characters(role);
+CREATE INDEX IF NOT EXISTS idx_characters_party         ON characters(party_id);
+CREATE INDEX IF NOT EXISTS idx_characters_current_zone  ON characters(current_zone_id);
+CREATE INDEX IF NOT EXISTS idx_characters_status        ON characters(status);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Unified proficiencies: skills, saves (name='save:str'), weapons, tools,
+-- custom/pet growth-skills all share this shape. docs/checks.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS character_proficiencies (
+    character_id   INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    name           TEXT NOT NULL,
+    proficient     INTEGER NOT NULL DEFAULT 0 CHECK (proficient IN (0,1)),
+    expertise      INTEGER NOT NULL DEFAULT 0 CHECK (expertise IN (0,1)),
+    ranks          INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (character_id, name)
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Limited-use resources: spell slots, mana, ki, rage, hit dice, etc.
+-- Generic — the agent interprets `name`. docs/characters.md §Resources
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS character_resources (
+    character_id   INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    name           TEXT NOT NULL,     -- 'slot:1' .. 'slot:9', 'hit_die', 'mana', 'ki', ...
+    current        INTEGER NOT NULL,
+    max            INTEGER NOT NULL,
+    recharge       TEXT NOT NULL CHECK (recharge IN
+                     ('short_rest','long_rest','dawn','never','manual')),
+    PRIMARY KEY (character_id, name)
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Conditions: named states with mechanical riders (defined in content, not here).
+-- docs/checks.md §Conditions
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS character_conditions (
+    id                    INTEGER PRIMARY KEY,
+    character_id          INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    condition             TEXT NOT NULL,    -- 'blinded', 'poisoned', 'exhaustion', etc.
+    severity              INTEGER NOT NULL DEFAULT 1,
+    source_event_id       INTEGER,
+    expires_at_hour       INTEGER,
+    expires_after_rounds  INTEGER,
+    remove_on_save        TEXT,             -- e.g. 'save:con:dc15'
+    active                INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0,1))
+);
+CREATE INDEX IF NOT EXISTS idx_conditions_character_active
+    ON character_conditions(character_id, active);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Effects: temporary numerical modifiers. Never mutate base stats.
+-- docs/checks.md §Effects
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS effects (
+    id                     INTEGER PRIMARY KEY,
+    target_character_id    INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    source                 TEXT NOT NULL,
+    target_kind            TEXT NOT NULL CHECK (target_kind IN
+                             ('ability','ac','speed','hp_max','attack','damage','skill','save','misc')),
+    target_key             TEXT NOT NULL,
+    modifier               INTEGER NOT NULL DEFAULT 0,
+    dice_expr              TEXT,
+    start_event_id         INTEGER NOT NULL,
+    expires_at_hour        INTEGER,
+    expires_after_rounds   INTEGER,
+    expires_on_dispel      INTEGER NOT NULL DEFAULT 0 CHECK (expires_on_dispel IN (0,1)),
+    active                 INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0,1))
+);
+CREATE INDEX IF NOT EXISTS idx_effects_target_active
+    ON effects(target_character_id, active);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Items: one table, location-mutex enforced by CHECK. docs/items.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS items (
+    id                    INTEGER PRIMARY KEY,
+    base_kind             TEXT NOT NULL,
+    name                  TEXT,
+    material              TEXT,
+    material_tier         INTEGER,
+    quality               TEXT,
+    quantity              INTEGER NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    charges               INTEGER,
+    charges_max           INTEGER,
+
+    holder_character_id   INTEGER REFERENCES characters(id) ON DELETE SET NULL,
+    container_item_id     INTEGER REFERENCES items(id)      ON DELETE SET NULL,
+    zone_location_id      INTEGER,     -- zones(id) — FK added via trigger-free CHECK
+
+    equipped_slot         TEXT,
+
+    created_at_event_id   INTEGER,
+    updated_at            INTEGER NOT NULL,
+
+    -- Exactly one of the three location FKs must be non-null.
+    CHECK (
+        ((holder_character_id IS NOT NULL)
+       + (container_item_id   IS NOT NULL)
+       + (zone_location_id    IS NOT NULL)) = 1
+    )
+);
+CREATE INDEX IF NOT EXISTS idx_items_holder        ON items(holder_character_id);
+CREATE INDEX IF NOT EXISTS idx_items_container     ON items(container_item_id);
+CREATE INDEX IF NOT EXISTS idx_items_zone          ON items(zone_location_id);
+CREATE INDEX IF NOT EXISTS idx_items_base_kind     ON items(base_kind);
+
+CREATE TABLE IF NOT EXISTS item_enchantments (
+    id                 INTEGER PRIMARY KEY,
+    item_id            INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    enchantment_kind   TEXT NOT NULL,
+    tier               INTEGER,
+    charges            INTEGER,
+    notes              TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_enchantments_item ON item_enchantments(item_id);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Zones, connections, landmarks. Graph-of-zones model. docs/world.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS zones (
+    id                     INTEGER PRIMARY KEY,
+    name                   TEXT NOT NULL,
+    biome                  TEXT NOT NULL,
+    kind                   TEXT NOT NULL CHECK (kind IN
+                             ('wilderness','settlement','dungeon','dungeon_floor',
+                              'dungeon_room','road','liminal')),
+    size                   TEXT NOT NULL CHECK (size IN
+                             ('tiny','small','medium','large','vast')),
+    parent_zone_id         INTEGER REFERENCES zones(id) ON DELETE CASCADE,
+    description            TEXT,
+    encounter_tags         TEXT NOT NULL DEFAULT '[]',   -- JSON array
+    created_at_event_id    INTEGER,
+    notes                  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_zones_parent ON zones(parent_zone_id);
+CREATE INDEX IF NOT EXISTS idx_zones_biome  ON zones(biome);
+
+CREATE TABLE IF NOT EXISTS zone_connections (
+    from_zone_id           INTEGER NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+    to_zone_id             INTEGER NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+    travel_time_hours      INTEGER NOT NULL CHECK (travel_time_hours >= 0),
+    travel_mode            TEXT NOT NULL CHECK (travel_mode IN
+                             ('road','wilderness','portal','passage','climb')),
+    hazard_tag             TEXT,
+    one_way                INTEGER NOT NULL DEFAULT 0 CHECK (one_way IN (0,1)),
+    direction_from         TEXT NOT NULL CHECK (direction_from IN
+                             ('n','ne','e','se','s','sw','w','nw','up','down')),
+    PRIMARY KEY (from_zone_id, to_zone_id)
+);
+
+CREATE TABLE IF NOT EXISTS landmarks (
+    id                       INTEGER PRIMARY KEY,
+    zone_id                  INTEGER NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+    name                     TEXT NOT NULL,
+    kind                     TEXT NOT NULL CHECK (kind IN
+                               ('settlement','dungeon_entrance','shop','temple',
+                                'ruin','natural_feature')),
+    description              TEXT,
+    position_note            TEXT,
+    hidden                   INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0,1)),
+    corresponds_to_zone_id   INTEGER REFERENCES zones(id) ON DELETE SET NULL,
+    created_at_event_id      INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_landmarks_zone ON landmarks(zone_id);
+
+-- Per-character fog of war. Monotonic upward — `level` only increases in normal play.
+CREATE TABLE IF NOT EXISTS character_zone_knowledge (
+    character_id         INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    zone_id              INTEGER NOT NULL REFERENCES zones(id)      ON DELETE CASCADE,
+    level                TEXT NOT NULL CHECK (level IN ('rumored','known','visited','mapped')),
+    first_event_id       INTEGER,
+    last_visit_at_hour   INTEGER,
+    PRIMARY KEY (character_id, zone_id)
+);
+
+CREATE TABLE IF NOT EXISTS character_landmark_knowledge (
+    character_id         INTEGER NOT NULL REFERENCES characters(id)  ON DELETE CASCADE,
+    landmark_id          INTEGER NOT NULL REFERENCES landmarks(id)   ON DELETE CASCADE,
+    level                TEXT NOT NULL CHECK (level IN ('rumored','known','visited')),
+    first_event_id       INTEGER,
+    last_visit_at_hour   INTEGER,
+    PRIMARY KEY (character_id, landmark_id)
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Encounters: combat is a mode of an encounter, not a separate table.
+-- docs/encounters.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS encounters (
+    id                         INTEGER PRIMARY KEY,
+    zone_id                    INTEGER REFERENCES zones(id) ON DELETE SET NULL,
+    name                       TEXT,
+    goal                       TEXT,
+    estimated_duration_hours   INTEGER NOT NULL DEFAULT 0,
+    xp_budget                  INTEGER NOT NULL DEFAULT 0,
+    status                     TEXT NOT NULL DEFAULT 'active'
+                                 CHECK (status IN
+                                   ('active','goal_completed','abandoned','failed')),
+
+    -- Combat state inline; NULL outside combat.
+    in_combat                  INTEGER NOT NULL DEFAULT 0 CHECK (in_combat IN (0,1)),
+    current_round              INTEGER,
+    turn_index                 INTEGER,
+
+    started_at_hour            INTEGER NOT NULL,
+    ended_at_hour              INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_encounters_zone     ON encounters(zone_id);
+CREATE INDEX IF NOT EXISTS idx_encounters_status   ON encounters(status);
+CREATE INDEX IF NOT EXISTS idx_encounters_combat   ON encounters(in_combat) WHERE in_combat=1;
+
+CREATE TABLE IF NOT EXISTS encounter_participants (
+    encounter_id             INTEGER NOT NULL REFERENCES encounters(id) ON DELETE CASCADE,
+    character_id             INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    side                     TEXT NOT NULL CHECK (side IN
+                               ('player_side','hostile','neutral','ally')),
+    initiative               INTEGER,
+    has_acted_this_round     INTEGER NOT NULL DEFAULT 0 CHECK (has_acted_this_round IN (0,1)),
+    PRIMARY KEY (encounter_id, character_id)
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- History / event log. Polymorphic; payload is JSON; participants + items
+-- junctions are the indexed path for "events involving X" queries.
+-- docs/history-log.md — append-only.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS events (
+    id              INTEGER PRIMARY KEY,
+    kind            TEXT NOT NULL,        -- dotted taxonomy: 'combat.hit', 'xp.goal', ...
+    campaign_hour   INTEGER NOT NULL,     -- may be negative (pre-campaign backstory)
+    combat_round    INTEGER,              -- set only for events inside combat
+    zone_id         INTEGER REFERENCES zones(id)      ON DELETE SET NULL,
+    encounter_id    INTEGER REFERENCES encounters(id) ON DELETE SET NULL,
+    parent_id       INTEGER REFERENCES events(id)     ON DELETE SET NULL,
+    summary         TEXT NOT NULL,
+    payload         TEXT NOT NULL DEFAULT '{}'    -- JSON
+);
+CREATE INDEX IF NOT EXISTS idx_events_zone_time     ON events(zone_id, campaign_hour DESC);
+CREATE INDEX IF NOT EXISTS idx_events_encounter     ON events(encounter_id);
+CREATE INDEX IF NOT EXISTS idx_events_parent        ON events(parent_id);
+CREATE INDEX IF NOT EXISTS idx_events_kind_time     ON events(kind, campaign_hour DESC);
+
+CREATE TABLE IF NOT EXISTS event_participants (
+    event_id       INTEGER NOT NULL REFERENCES events(id)     ON DELETE CASCADE,
+    character_id   INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    role           TEXT NOT NULL CHECK (role IN
+                     ('actor','target','witness','beneficiary')),
+    PRIMARY KEY (event_id, character_id, role)
+);
+-- Hottest query path: "events involving character X".
+CREATE INDEX IF NOT EXISTS idx_event_participants_char
+    ON event_participants(character_id, event_id);
+
+CREATE TABLE IF NOT EXISTS event_items (
+    event_id   INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    item_id    INTEGER NOT NULL REFERENCES items(id)  ON DELETE CASCADE,
+    role       TEXT NOT NULL,   -- 'stolen' | 'given' | 'destroyed' | 'actor' | etc.
+    PRIMARY KEY (event_id, item_id, role)
+);
+CREATE INDEX IF NOT EXISTS idx_event_items_item ON event_items(item_id, event_id);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Campaign lifecycle (singleton + setup-phase answers).
+-- docs/campaign-setup.md
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS campaign_state (
+    id                     INTEGER PRIMARY KEY CHECK (id = 1),   -- singleton
+    phase                  TEXT NOT NULL CHECK (phase IN ('setup','running')),
+    started_at             INTEGER,      -- real-time epoch ms when mark_ready fired
+    player_character_id    INTEGER REFERENCES characters(id) ON DELETE SET NULL
+);
+
+-- Seed the singleton row in the 'setup' phase if missing. Insert OR IGNORE makes the
+-- migration idempotent on re-open.
+INSERT OR IGNORE INTO campaign_state (id, phase) VALUES (1, 'setup');
+
+CREATE TABLE IF NOT EXISTS campaign_setup_answers (
+    question_id   TEXT PRIMARY KEY,
+    answer        TEXT NOT NULL,   -- JSON; array for multi-select, string/scalar otherwise
+    answered_at   INTEGER NOT NULL
+);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("enable foreign keys");
+        conn
+    }
+
+    fn table_names(conn: &Connection) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap();
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        rows
+    }
+
+    #[test]
+    fn migrate_creates_every_expected_table() {
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("first migrate");
+        let tables = table_names(&conn);
+        for expected in EXPECTED_TABLES {
+            assert!(
+                tables.iter().any(|t| t == expected),
+                "missing table {expected}; got {tables:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("first migrate");
+        migrate(&mut conn).expect("second migrate should be a no-op");
+        let tables = table_names(&conn);
+        // Same table set both times.
+        for expected in EXPECTED_TABLES {
+            assert!(tables.iter().any(|t| t == expected));
+        }
+    }
+
+    #[test]
+    fn campaign_state_singleton_is_seeded_in_setup_phase() {
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("migrate");
+        let phase: String = conn
+            .query_row("SELECT phase FROM campaign_state WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .expect("singleton row exists");
+        assert_eq!(phase, "setup");
+    }
+
+    #[test]
+    fn campaign_state_refuses_second_row() {
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("migrate");
+        let err = conn
+            .execute(
+                "INSERT INTO campaign_state (id, phase) VALUES (2, 'running')",
+                [],
+            )
+            .expect_err("second row should violate the CHECK (id = 1)");
+        assert!(
+            format!("{err:#}").contains("CHECK"),
+            "expected CHECK violation, got {err}"
+        );
+    }
+
+    #[test]
+    fn item_location_mutex_is_enforced() {
+        // Create a character so the holder FK resolves.
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO characters (
+                name, role,
+                str_score, dex_score, con_score, int_score, wis_score, cha_score,
+                hp_current, hp_max, armor_class,
+                created_at, updated_at
+            ) VALUES (?1, 'player', 10,10,10,10,10,10, 10, 10, 10, 0, 0)",
+            ["Kira"],
+        )
+        .expect("insert character");
+
+        // No location → rejected (CHECK = 1).
+        let err = conn
+            .execute(
+                "INSERT INTO items (base_kind, quantity, updated_at) VALUES ('gold', 1, 0)",
+                [],
+            )
+            .expect_err("item with no location should be rejected");
+        assert!(format!("{err:#}").contains("CHECK"));
+
+        // Two locations → rejected.
+        let err = conn
+            .execute(
+                "INSERT INTO items (base_kind, quantity, holder_character_id, zone_location_id, updated_at)
+                 VALUES ('gold', 1, 1, 999, 0)",
+                [],
+            )
+            .expect_err("item with two locations should be rejected");
+        assert!(format!("{err:#}").contains("CHECK"));
+
+        // Exactly one → accepted.
+        conn.execute(
+            "INSERT INTO items (base_kind, quantity, holder_character_id, updated_at)
+             VALUES ('gold', 5, 1, 0)",
+            [],
+        )
+        .expect("holder-only item should be accepted");
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -217,7 +217,10 @@ CREATE TABLE IF NOT EXISTS items (
 
     holder_character_id   INTEGER REFERENCES characters(id) ON DELETE SET NULL,
     container_item_id     INTEGER REFERENCES items(id)      ON DELETE SET NULL,
-    zone_location_id      INTEGER,     -- zones(id) — FK added via trigger-free CHECK
+    -- SQLite allows forward-referencing FKs in the same DDL batch; `zones` is created
+    -- further down this same migration and the FK resolves at execute time under
+    -- foreign_keys=ON. Symmetric with the other two location columns.
+    zone_location_id      INTEGER REFERENCES zones(id)      ON DELETE SET NULL,
 
     equipped_slot         TEXT,
 
@@ -531,5 +534,42 @@ mod tests {
             [],
         )
         .expect("holder-only item should be accepted");
+    }
+
+    #[test]
+    fn item_zone_location_fk_is_enforced() {
+        // Regression guard: previously zone_location_id had no FK declared, so an item
+        // could reference a nonexistent zone. The previous mutex test masked this by also
+        // setting holder_character_id, which made the mutex CHECK reject the row before
+        // the FK could matter.
+        let mut conn = in_memory();
+        migrate(&mut conn).expect("migrate");
+
+        // No zones exist. zone_location_id=999 should fail the FK.
+        let err = conn
+            .execute(
+                "INSERT INTO items (base_kind, quantity, zone_location_id, updated_at)
+                 VALUES ('gold', 1, 999, 0)",
+                [],
+            )
+            .expect_err("zone_location_id pointing at nonexistent zone should be rejected");
+        assert!(
+            format!("{err:#}").contains("FOREIGN KEY"),
+            "expected FOREIGN KEY violation, got {err}"
+        );
+
+        // Insert a real zone and then the item should be accepted.
+        conn.execute(
+            "INSERT INTO zones (id, name, biome, kind, size)
+             VALUES (1, 'Test', 'temperate_forest', 'wilderness', 'small')",
+            [],
+        )
+        .expect("insert zone");
+        conn.execute(
+            "INSERT INTO items (base_kind, quantity, zone_location_id, updated_at)
+             VALUES ('gold', 1, 1, 0)",
+            [],
+        )
+        .expect("item referencing real zone should be accepted");
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,13 +1,17 @@
 //! MCP server handler. Transport-agnostic: the same handler instance is attached to either
 //! the stdio or HTTP transport.
 //!
-//! Phase 1 registers a single tool — `server.info` — returning version and active transport.
-//! Later phases add the full tool surface via the same `#[tool_router]` pattern.
+//! Phase 1 registered `server.info`. Phase 2 adds `content.introspect`. Later phases add
+//! the full tool surface via the same `#[tool_router]` pattern.
+
+use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
 use serde::Serialize;
+
+use crate::content::Content as ContentCatalog;
 
 /// The transport this server instance is currently serving. Reported by `server.info`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -41,15 +45,17 @@ struct ServerInfoPayload {
 #[derive(Clone)]
 pub struct DmMcpHandler {
     transport: Transport,
+    content: Arc<ContentCatalog>,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
 
 #[tool_router]
 impl DmMcpHandler {
-    pub fn new(transport: Transport) -> Self {
+    pub fn new(transport: Transport, content: Arc<ContentCatalog>) -> Self {
         Self {
             transport,
+            content,
             tool_router: Self::tool_router(),
         }
     }
@@ -73,6 +79,23 @@ impl DmMcpHandler {
         })?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
+
+    /// Return a structured summary of every content section loaded at startup — one list
+    /// of IDs per section. Lets the DM agent confirm which catalog it's running against.
+    #[tool(
+        name = "content.introspect",
+        description = "Return the IDs of every entry loaded from the bundled YAML content catalog (abilities, skills, damage types, conditions, biomes, weapons, enchantments, archetypes)."
+    )]
+    async fn content_introspect(&self) -> Result<CallToolResult, McpError> {
+        let introspection = self.content.introspect();
+        let json = serde_json::to_string(&introspection).map_err(|e| {
+            McpError::internal_error(
+                format!("failed to serialize content.introspect payload: {e}"),
+                None,
+            )
+        })?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 }
 
 #[tool_handler]
@@ -87,8 +110,7 @@ impl ServerHandler for DmMcpHandler {
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.server_info = implementation;
         info.instructions = Some(
-            "dm-mcp: MCP toolkit for AI Dungeon Masters. Phase 1 skeleton — only server.info is live."
-                .to_string(),
+            "dm-mcp: MCP toolkit for AI Dungeon Masters. Phase 2 adds the campaign DB and content catalog; server.info + content.introspect are live.".to_string(),
         );
         info
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 //! dm-mcp — MCP toolkit for AI Dungeon Masters running solo d20-inspired RPG campaigns.
 //!
-//! CLI entry point. Dispatches to one of the two transport modules based on the chosen
-//! subcommand. See [`docs/architecture.md`](../docs/architecture.md) for design rationale.
+//! CLI entry point. Loads config from env vars, opens the campaign database (applying every
+//! PRAGMA), parses bundled YAML content into memory, then dispatches to the chosen transport.
+//! See [`docs/architecture.md`](../docs/architecture.md) for design rationale.
+
+use std::sync::Arc;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -9,10 +12,14 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 mod config;
+mod content;
+mod db;
 mod handler;
 mod transport;
 
 use crate::config::Config;
+use crate::content::Content;
+use crate::db::Database;
 
 /// dm-mcp — MCP toolkit for AI Dungeon Masters running solo d20-inspired RPG campaigns.
 #[derive(Parser, Debug)]
@@ -41,9 +48,31 @@ async fn main() -> Result<()> {
 
     init_tracing(&cli.transport, &cfg.log_level)?;
 
+    // Load bundled (or overridden) content once. Held in an Arc so both transports can
+    // share a single catalog across MCP sessions.
+    let content = Arc::new(Content::load(cfg.content_dir.as_deref())?);
+    tracing::info!(
+        abilities = content.abilities.len(),
+        skills = content.skills.len(),
+        damage_types = content.damage_types.len(),
+        conditions = content.conditions.len(),
+        biomes = content.biomes.len(),
+        weapons = content.weapons.len(),
+        enchantments = content.enchantments.len(),
+        archetypes = content.archetypes.len(),
+        "dm-mcp: content catalog loaded"
+    );
+
+    // Open the campaign database — applies PRAGMAs and runs migrations. The handle is held
+    // here for the process lifetime; Phase 2 doesn't yet expose tools that query it, but
+    // opening at startup satisfies the Phase 2 E2E assertion (fresh DB on first run with
+    // every expected table present) and catches config / permission problems up front.
+    let _db = Database::open(&cfg.db)?;
+    tracing::info!(path = %cfg.db.path.display(), "dm-mcp: campaign database opened");
+
     match cli.transport {
-        TransportCmd::Stdio => transport::stdio::run().await,
-        TransportCmd::Http => transport::http::run(&cfg.http).await,
+        TransportCmd::Stdio => transport::stdio::run(content).await,
+        TransportCmd::Http => transport::http::run(&cfg.http, content).await,
     }
 }
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -20,6 +20,7 @@ use rmcp::transport::streamable_http_server::tower::{
 use tokio_util::sync::CancellationToken;
 
 use crate::config::HttpConfig;
+use crate::content::Content;
 use crate::handler::{DmMcpHandler, Transport};
 
 #[derive(Clone)]
@@ -27,17 +28,21 @@ struct HealthState;
 
 /// Run the HTTP transport, serving MCP under `/mcp` and health under `/healthz`.
 ///
-/// Completes when a shutdown signal is received (SIGINT) and all in-flight requests drain.
-pub async fn run(cfg: &HttpConfig) -> Result<()> {
+/// Completes when a shutdown signal is received (SIGINT / SIGTERM) and all in-flight
+/// requests drain.
+pub async fn run(cfg: &HttpConfig, content: Arc<Content>) -> Result<()> {
     let addr = cfg.socket_addr();
     tracing::info!(bind = %addr, "dm-mcp: serving MCP over HTTP");
 
     let cancel = CancellationToken::new();
 
-    // Factory: each new MCP session gets its own handler instance. The handler is cheap to
-    // construct; future phases may share more state via Arc inside DmMcpHandler.
+    // Factory: each new MCP session gets its own handler instance, sharing the same
+    // content catalog via Arc clone.
     let mcp_service = StreamableHttpService::new(
-        || Ok(DmMcpHandler::new(Transport::Http)),
+        {
+            let content = Arc::clone(&content);
+            move || Ok(DmMcpHandler::new(Transport::Http, Arc::clone(&content)))
+        },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default().with_cancellation_token(cancel.child_token()),
     );

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -3,16 +3,19 @@
 //! The lowest-latency transport: attach the MCP server directly to the process's stdin/stdout.
 //! Chosen for local DM-agent setups. See `docs/architecture.md`.
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use rmcp::transport::stdio;
 use rmcp::ServiceExt;
 
+use crate::content::Content;
 use crate::handler::{DmMcpHandler, Transport};
 
 /// Run the MCP server over stdin/stdout until the peer closes the connection.
-pub async fn run() -> Result<()> {
+pub async fn run(content: Arc<Content>) -> Result<()> {
     tracing::info!("dm-mcp: serving MCP over stdio");
-    let handler = DmMcpHandler::new(Transport::Stdio);
+    let handler = DmMcpHandler::new(Transport::Stdio, content);
     let service = handler.serve(stdio()).await?;
     service.waiting().await?;
     Ok(())

--- a/tests/content_introspect.rs
+++ b/tests/content_introspect.rs
@@ -1,0 +1,119 @@
+//! E2E test for Phase 2: spawn the stdio transport, call `content.introspect`, assert the
+//! response contains the expected content IDs for every loaded section.
+
+use anyhow::{Context, Result};
+use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::transport::TokioChildProcess;
+use rmcp::ServiceExt;
+use tempfile::TempDir;
+use tokio::process::Command;
+
+fn bin_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
+}
+
+async fn connect_with_db(
+    db_path: &std::path::Path,
+) -> Result<rmcp::service::RunningService<rmcp::service::RoleClient, ()>> {
+    let mut cmd = Command::new(bin_path());
+    cmd.arg("stdio");
+    cmd.env("DMMCP_LOG_LEVEL", "warn");
+    cmd.env("DMMCP_DB_PATH", db_path);
+    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
+    let client = ().serve(transport).await.context("mcp handshake")?;
+    Ok(client)
+}
+
+#[tokio::test]
+async fn content_introspect_returns_every_section() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
+    let client = connect_with_db(&db_path).await?;
+
+    // Tool must appear in list_tools.
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|t| t.name == "content.introspect"),
+        "content.introspect should be listed; got {:?}",
+        tools.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+
+    // Call it and parse the JSON payload.
+    let result = client
+        .call_tool(CallToolRequestParams::new("content.introspect"))
+        .await
+        .context("call content.introspect")?;
+    assert!(
+        result.is_error != Some(true),
+        "tool should not signal error, got {:?}",
+        result.is_error
+    );
+    let text = result
+        .content
+        .iter()
+        .find_map(|item| match &item.raw {
+            RawContent::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .context("expected text content in response")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("introspect payload should be JSON, got: {text}"))?;
+
+    // Expected section -> at least one ID it must contain.
+    let expectations: &[(&str, &[&str])] = &[
+        ("abilities", &["str", "cha", "con"]),
+        ("skills", &["stealth", "persuasion", "perception"]),
+        ("damage_types", &["fire", "slashing", "necrotic"]),
+        ("conditions", &["blinded", "paralyzed", "mortally_wounded"]),
+        ("biomes", &["temperate_forest"]),
+        ("weapons", &["longsword"]),
+        ("enchantments", &["glowing"]),
+        ("archetypes", &["village_elder"]),
+    ];
+    for (section, required_ids) in expectations {
+        let arr = parsed
+            .get(*section)
+            .and_then(|v| v.as_array())
+            .with_context(|| {
+                format!("section {section} should be an array; payload was {parsed}")
+            })?;
+        let ids: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+        for required in *required_ids {
+            assert!(
+                ids.iter().any(|id| id == required),
+                "section {section} should contain {required}; got {ids:?}"
+            );
+        }
+    }
+
+    client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn server_info_still_works_alongside_new_tool() -> Result<()> {
+    // Phase 1's smoke test still needs to pass after adding new tools — make sure we haven't
+    // regressed the router by adding content.introspect.
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
+    let client = connect_with_db(&db_path).await?;
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("server.info"))
+        .await?;
+    assert!(result.is_error != Some(true));
+    let text = result
+        .content
+        .iter()
+        .find_map(|item| match &item.raw {
+            RawContent::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .context("expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text)?;
+    assert_eq!(parsed["name"], "dm-mcp");
+    assert_eq!(parsed["transport"], "stdio");
+
+    client.cancel().await?;
+    Ok(())
+}

--- a/tests/healthz.rs
+++ b/tests/healthz.rs
@@ -6,6 +6,7 @@
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
+use tempfile::TempDir;
 use tokio::process::{Child, Command};
 use tokio::time::sleep;
 
@@ -45,12 +46,14 @@ async fn wait_for_healthz(url: &str, timeout: Duration) -> anyhow::Result<reqwes
     ))
 }
 
-async fn spawn_http(port: u16) -> anyhow::Result<Child> {
+async fn spawn_http(port: u16, db_path: &std::path::Path) -> anyhow::Result<Child> {
     let child = Command::new(bin_path())
         .arg("http")
         .env("DMMCP_HTTP_BIND", "127.0.0.1")
         .env("DMMCP_HTTP_PORT", port.to_string())
         .env("DMMCP_LOG_LEVEL", "warn")
+        // Each test gets its own DB file so parallel tests don't race on migration.
+        .env("DMMCP_DB_PATH", db_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         // Discard stderr — the tests don't assert on log output, and a piped-but-undrained
@@ -63,8 +66,10 @@ async fn spawn_http(port: u16) -> anyhow::Result<Child> {
 
 #[tokio::test]
 async fn healthz_returns_ok_when_http_transport_is_running() -> anyhow::Result<()> {
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
     let port = test_port();
-    let mut child = spawn_http(port).await?;
+    let mut child = spawn_http(port, &db_path).await?;
 
     let url = format!("http://127.0.0.1:{port}/healthz");
     let resp = wait_for_healthz(&url, Duration::from_secs(10)).await?;
@@ -81,8 +86,10 @@ async fn healthz_returns_ok_when_http_transport_is_running() -> anyhow::Result<(
 async fn healthz_returns_ok_on_repeated_calls() -> anyhow::Result<()> {
     // Readiness / liveness probes hit /healthz repeatedly. Make sure we're not holding
     // state between calls that would cause drift.
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
     let port = test_port() + 1;
-    let mut child = spawn_http(port).await?;
+    let mut child = spawn_http(port, &db_path).await?;
 
     let url = format!("http://127.0.0.1:{port}/healthz");
     // First call also serves as the warm-up wait.

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -44,7 +44,11 @@ fn bin_path() -> std::path::PathBuf {
 }
 
 fn test_port() -> u16 {
-    const BASE: u16 = 18_500;
+    // Shifted to 19_500..20_499 so the PID-derived port can never collide with
+    // tests/healthz.rs (18_000..18_999) regardless of how the PID values line up.
+    // Ideally the binary would bind 127.0.0.1:0 and report its port back; that's a
+    // follow-up when we gain a "report-bound-port" signal on the HTTP transport.
+    const BASE: u16 = 19_500;
     BASE + (std::process::id() as u16 % 1_000)
 }
 

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,0 +1,126 @@
+//! E2E test for Phase 2: spawning the binary against a fresh DB path creates the file
+//! with every expected table.
+//!
+//! The binary is launched in HTTP mode (any transport would do; HTTP is used here because
+//! `/healthz` gives us a synchronous "you can stop now" signal). We hit `/healthz`, verify
+//! the DB file was created, open it read-only, and confirm the schema.
+
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+use tokio::process::{Child, Command};
+use tokio::time::sleep;
+
+/// Tables the schema must create. Kept in sync with `src/db/schema.rs::EXPECTED_TABLES` —
+/// integration tests shouldn't reach into crate internals, so the list is duplicated here
+/// deliberately.
+const EXPECTED_TABLES: &[&str] = &[
+    "parties",
+    "characters",
+    "character_proficiencies",
+    "character_resources",
+    "character_conditions",
+    "effects",
+    "items",
+    "item_enchantments",
+    "zones",
+    "zone_connections",
+    "landmarks",
+    "character_zone_knowledge",
+    "character_landmark_knowledge",
+    "encounters",
+    "encounter_participants",
+    "events",
+    "event_participants",
+    "event_items",
+    "campaign_state",
+    "campaign_setup_answers",
+];
+
+fn bin_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
+}
+
+fn test_port() -> u16 {
+    const BASE: u16 = 18_500;
+    BASE + (std::process::id() as u16 % 1_000)
+}
+
+async fn wait_for_healthz(url: &str, timeout: Duration) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(resp) = client.get(url).send().await {
+            if resp.status() == 200 {
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    Err(anyhow::anyhow!("timed out waiting for {url}"))
+}
+
+async fn spawn_http(port: u16, db_path: &std::path::Path) -> anyhow::Result<Child> {
+    let child = Command::new(bin_path())
+        .arg("http")
+        .env("DMMCP_HTTP_BIND", "127.0.0.1")
+        .env("DMMCP_HTTP_PORT", port.to_string())
+        .env("DMMCP_LOG_LEVEL", "warn")
+        .env("DMMCP_DB_PATH", db_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+    Ok(child)
+}
+
+#[tokio::test]
+async fn fresh_start_creates_db_with_every_expected_table() -> anyhow::Result<()> {
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
+    assert!(!db_path.exists(), "precondition: db should not exist yet");
+
+    let port = test_port();
+    let mut child = spawn_http(port, &db_path).await?;
+    wait_for_healthz(
+        &format!("http://127.0.0.1:{port}/healthz"),
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    assert!(
+        db_path.exists(),
+        "db file should be created by the server on startup"
+    );
+
+    // Open read-only to inspect the schema the server wrote.
+    let conn = Connection::open(&db_path)?;
+    let mut stmt =
+        conn.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")?;
+    let tables: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    for expected in EXPECTED_TABLES {
+        assert!(
+            tables.iter().any(|t| t == expected),
+            "missing table {expected}; got {tables:?}"
+        );
+    }
+
+    // The campaign singleton row must exist and be in 'setup'.
+    let phase: String =
+        conn.query_row("SELECT phase FROM campaign_state WHERE id = 1", [], |r| {
+            r.get(0)
+        })?;
+    assert_eq!(phase, "setup");
+
+    child.kill().await?;
+    Ok(())
+}

--- a/tests/stdio_server_info.rs
+++ b/tests/stdio_server_info.rs
@@ -7,16 +7,22 @@ use anyhow::{Context, Result};
 use rmcp::model::{CallToolRequestParams, RawContent};
 use rmcp::transport::TokioChildProcess;
 use rmcp::ServiceExt;
+use tempfile::TempDir;
 use tokio::process::Command;
 
 fn bin_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
 }
 
-async fn connect() -> Result<rmcp::service::RunningService<rmcp::service::RoleClient, ()>> {
+/// Spawn the binary with an isolated tmp campaign DB. Tests run in parallel by default,
+/// so sharing `./campaign.db` between spawns would race on schema migration.
+async fn connect(
+    _tmp: &TempDir,
+) -> Result<rmcp::service::RunningService<rmcp::service::RoleClient, ()>> {
     let mut cmd = Command::new(bin_path());
     cmd.arg("stdio");
     cmd.env("DMMCP_LOG_LEVEL", "warn");
+    cmd.env("DMMCP_DB_PATH", _tmp.path().join("campaign.db"));
     let transport = TokioChildProcess::new(cmd).context("spawn child")?;
     let client = ().serve(transport).await.context("mcp handshake")?;
     Ok(client)
@@ -24,7 +30,8 @@ async fn connect() -> Result<rmcp::service::RunningService<rmcp::service::RoleCl
 
 #[tokio::test]
 async fn handshake_and_peer_info_reports_server_name() -> Result<()> {
-    let client = connect().await?;
+    let tmp = TempDir::new()?;
+    let client = connect(&tmp).await?;
 
     let info = client
         .peer_info()
@@ -45,7 +52,8 @@ async fn handshake_and_peer_info_reports_server_name() -> Result<()> {
 
 #[tokio::test]
 async fn server_info_tool_is_listed() -> Result<()> {
-    let client = connect().await?;
+    let tmp = TempDir::new()?;
+    let client = connect(&tmp).await?;
 
     let tools = client.list_all_tools().await?;
     assert!(
@@ -60,7 +68,8 @@ async fn server_info_tool_is_listed() -> Result<()> {
 
 #[tokio::test]
 async fn server_info_tool_returns_expected_shape() -> Result<()> {
-    let client = connect().await?;
+    let tmp = TempDir::new()?;
+    let client = connect(&tmp).await?;
 
     let result = client
         .call_tool(CallToolRequestParams::new("server.info"))


### PR DESCRIPTION
## Summary

Phase 2 of the Roadmap: the campaign database, the bundled content catalog, and the \`content.introspect\` tool that exposes the catalog over MCP.

- **Schema**: 20 tables covering every entity the design docs specify — characters, parties, proficiencies, resources, conditions, effects, items, item_enchantments, zones, zone_connections, landmarks, knowledge tables, encounters, encounter_participants, events, event_participants, event_items, campaign_state (singleton with \`CHECK id=1\`), campaign_setup_answers. Created atomically in one transaction at startup; \`CREATE IF NOT EXISTS\` makes reopens idempotent. Indexes on the hot paths called out in \`docs/history-log.md\` (e.g. \`event_participants(character_id, event_id)\`).
- **Connection opener** applies the configured PRAGMAs (\`journal_mode\`, \`synchronous\`, \`mmap_size\`, \`cache_size\`) plus \`foreign_keys=ON\` and \`temp_store=MEMORY\` (hard-coded — correctness + latency, not tuning). Uses \`rusqlite\` with the \`bundled\` feature so SQLite links statically; no OpenSSL, no system sqlite.
- **Content loader** parses bundled YAML under \`content/\` into typed Rust structs at startup. Phase 2 ships: abilities, skills, damage_types, conditions (with mechanical riders), one biome (\`temperate_forest\`), one weapon base (\`longsword\`), one enchantment (\`glowing\`), one archetype (\`village_elder\`). \`DMMCP_CONTENT_DIR\` loads from disk instead of the embedded copy. Cross-section validation (skills must reference real abilities).
- **content.introspect** tool returns a JSON object with one ID list per section; lets a DM agent confirm which catalog it's running against without having to parse YAML.

### Non-code / hygiene

- **\`serde_yaml_ng\` in place of \`serde_yaml\`** — the original crate is deprecated (author stepped away); \`serde_yaml_ng\` is a maintained drop-in fork.
- **Test DB isolation** — \`tests/healthz.rs\` and \`tests/stdio_server_info.rs\` now set \`DMMCP_DB_PATH\` to a per-test TempDir. Parallel tests would otherwise race on the migration of the shared \`./campaign.db\`.

## Test plan

| Target | Result |
|---|---|
| \`cargo fmt --check\` | clean |
| \`cargo clippy --all-targets -- -D warnings\` | clean |
| \`cargo test\` | **27/27 pass** |
| \`cargo tree -i openssl\|openssl-sys\|native-tls\` | empty |
| \`cargo audit\` | clean (308 crates) |
| \`cargo build --release\` | succeeds (~9 min on Pi) |

### Roadmap E2E assertion

> Delete DB file → start server → file exists with all expected tables. \`content.introspect\` response contains expected content IDs.

- [x] \`tests/schema.rs::fresh_start_creates_db_with_every_expected_table\` — deletes any DB, starts the server with \`DMMCP_DB_PATH\` in a tempdir, waits for \`/healthz\`, opens read-only, asserts every expected table + campaign_state singleton seeded in \`setup\`.
- [x] \`tests/content_introspect.rs::content_introspect_returns_every_section\` — stdio handshake → \`content.introspect\` → assert every section contains the expected IDs.
- [x] Regression test: \`server.info\` still works alongside the new tool.

## What's next

Phase 3 — Dice (\`feature/phase-3-dice\`): \`dice.roll\` tool supporting d4–d100, arbitrary ranges (\`11-43\`), and multi-dice (\`3d6\`) with per-die results + sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `content.introspect` tool to retrieve comprehensive game content and rules
  * Integrated bundled content: core abilities and skills, damage types, status conditions, world biomes, weapons, enchantments, and NPC archetypes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->