### PR TITLE
Container build + release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+target
+.git
+.github
+.claude
+.pids
+.logs
+
+# Local campaign DB + WAL sidecars from `make dev`
+campaign.db
+campaign.db-wal
+campaign.db-shm
+
+# Not needed for the build
+docs
+examples
+tests
+*.md
+Makefile
+LICENSE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,144 @@
+name: Container Build and Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allow manual triggering
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  create-tag:
+    name: Create Semantic Version Tag
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+      changelog: ${{ steps.tag.outputs.changelog }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          release_branches: main
+          tag_prefix: v
+
+  build-and-push:
+    name: Build and Push dm-mcp Container
+    runs-on: ubuntu-latest
+    needs: create-tag
+    if: needs.create-tag.outputs.new_tag
+    steps:
+      - name: Maximize Build Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.create-tag.outputs.new_tag }}
+          labels: |
+            org.opencontainers.image.title=dm-mcp
+            org.opencontainers.image.description=MCP toolkit for AI Dungeon Masters running solo d20-inspired RPG campaigns
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          platforms: linux/amd64
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [create-tag, build-and-push]
+    if: needs.create-tag.outputs.new_tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.create-tag.outputs.new_tag }}
+          name: Release ${{ needs.create-tag.outputs.new_tag }}
+          body: |
+            ## 🚀 What's Changed
+            ${{ needs.create-tag.outputs.changelog }}
+
+            ## 📦 Container Image
+            - `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-tag.outputs.new_tag }}`
+            - `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest`
+
+            ## 🛠️ Usage
+            ```bash
+            # HTTP transport (default; binds 0.0.0.0:3000, exposes /healthz)
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            docker run --rm -p 3000:3000 \
+              -v dm-mcp-data:/data \
+              -e DMMCP_DB_PATH=/data/campaign.db \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+            # stdio transport (for local DM-agent subprocess use)
+            docker run --rm -i \
+              -v dm-mcp-data:/data \
+              -e DMMCP_DB_PATH=/data/campaign.db \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest stdio
+            ```
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ env:
 permissions:
   contents: write
   packages: write
+  # Required by docker/build-push-action's provenance/SBOM attestations, which
+  # request an OIDC token to sign the attestation manifest.
   id-token: write
 
 # Serialise release runs on the same ref so rapid main commits don't race each
@@ -76,9 +78,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # docker/metadata-action@v6 and docker/build-push-action@v7 are JS
+      # actions on the Node.js 24 runtime — require GitHub Actions runner
+      # v2.327.1+. ubuntu-latest is well past that; self-hosted runners (ARC)
+      # should confirm before switching to them here.
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -91,7 +97,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Containerfile
@@ -106,6 +112,11 @@ jobs:
             type=gha,mode=max
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           platforms: linux/amd64
+          # SLSA provenance + SPDX SBOM attached as OCI attestations. Consumers
+          # can verify provenance with `cosign verify-attestation` or
+          # `docker buildx imagetools inspect --format '{{json .Provenance}}'`.
+          provenance: mode=max
+          sbom: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,19 @@ permissions:
   packages: write
   id-token: write
 
+# Serialise release runs on the same ref so rapid main commits don't race each
+# other computing / pushing tags. `cancel-in-progress: false` lets an in-flight
+# release finish cleanly before the next one starts.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  create-tag:
-    name: Create Semantic Version Tag
+  # Computes the next semver tag without pushing it. The tag is pushed from
+  # build-and-push after the image upload succeeds, so a build failure can't
+  # leave an orphan tag in the repo.
+  compute-tag:
+    name: Compute Next Version Tag
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
@@ -29,12 +39,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure Git
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-      - name: Bump version and push tag
+      - name: Compute next tag (dry run — tag pushed after image build)
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -42,12 +47,13 @@ jobs:
           default_bump: patch
           release_branches: main
           tag_prefix: v
+          dry_run: true
 
   build-and-push:
     name: Build and Push dm-mcp Container
     runs-on: ubuntu-latest
-    needs: create-tag
-    if: needs.create-tag.outputs.new_tag
+    needs: compute-tag
+    if: needs.compute-tag.outputs.new_tag
     steps:
       - name: Maximize Build Space
         run: |
@@ -78,7 +84,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ needs.create-tag.outputs.new_tag }}
+            type=raw,value=${{ needs.compute-tag.outputs.new_tag }}
           labels: |
             org.opencontainers.image.title=dm-mcp
             org.opencontainers.image.description=MCP toolkit for AI Dungeon Masters running solo d20-inspired RPG campaigns
@@ -103,26 +109,34 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
+      # Push the git tag only after the image upload succeeds, so a failed
+      # build can't leave a tag pointing at a commit with no corresponding
+      # image. The checkout above persists GITHUB_TOKEN for git operations.
+      - name: Push git tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "${{ needs.compute-tag.outputs.new_tag }}" \
+            -m "Release ${{ needs.compute-tag.outputs.new_tag }}"
+          git push origin "${{ needs.compute-tag.outputs.new_tag }}"
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [create-tag, build-and-push]
-    if: needs.create-tag.outputs.new_tag
+    needs: [compute-tag, build-and-push]
+    if: needs.compute-tag.outputs.new_tag
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.create-tag.outputs.new_tag }}
-          name: Release ${{ needs.create-tag.outputs.new_tag }}
+          tag_name: ${{ needs.compute-tag.outputs.new_tag }}
+          name: Release ${{ needs.compute-tag.outputs.new_tag }}
           body: |
             ## 🚀 What's Changed
-            ${{ needs.create-tag.outputs.changelog }}
+            ${{ needs.compute-tag.outputs.changelog }}
 
             ## 📦 Container Image
-            - `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-tag.outputs.new_tag }}`
+            - `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.compute-tag.outputs.new_tag }}`
             - `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest`
 
             ## 🛠️ Usage

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.7
+
+# ─── STAGE 1: Build dm-mcp as a statically-linked musl binary ────────────────
+FROM rust:1 AS builder
+
+# musl toolchain. rusqlite's "bundled" feature compiles SQLite from C source,
+# so the musl C compiler is required for the x86_64-unknown-linux-musl target.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends musl-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /app
+
+# Single-crate project, so no workspace cache dance. `content/` is embedded
+# into the binary at compile time via include_dir!, so it must be present
+# here — but it is NOT needed in the final image.
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY content ./content
+
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin dm-mcp
+
+# ─── STAGE 2: scratch runtime ────────────────────────────────────────────────
+FROM scratch
+
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/dm-mcp /dm-mcp
+
+# HTTP transport binds 0.0.0.0:3000 by default and exposes /healthz. Override
+# with DMMCP_HTTP_BIND / DMMCP_HTTP_PORT. stdio transport does not use the
+# network.
+EXPOSE 3000
+
+# One campaign per process — mount a volume for the SQLite file and point
+# DMMCP_DB_PATH at it (default is ./campaign.db, which will be inside the
+# container's writable layer and lost on restart).
+
+# Default to HTTP for k8s / networked deploys. Override with `stdio` for
+# local DM-agent subprocess use.
+ENTRYPOINT ["/dm-mcp"]
+CMD ["http"]


### PR DESCRIPTION
## Summary
- Multi-stage `Containerfile` builds `dm-mcp` as a statically-linked musl binary and ships it in a `scratch` image (defaults to `http` transport, override with `stdio`).
- `.github/workflows/release.yaml` auto-tags on push to `main`, builds the image with GHA + registry buildcache, and publishes it to GHCR with a GitHub release.
- `.dockerignore` keeps `target/`, `docs/`, local DB files, etc. out of the build context.

### Notes
- `content/` is embedded at compile time via `include_dir!`, so the runtime layer is just the binary — no content copy needed.
- TLS is expected to terminate at the k8s ingress (standard pattern). The scratch image has no CA bundle because dm-mcp makes no outbound network calls.
- Release workflow runs on `ubuntu-latest` (Docker-guaranteed); existing CI on `arc-runner-dm-mcp` is unchanged.
- Using `softprops/action-gh-release@v2` instead of the archived `actions/create-release@v1`.

## Test plan
- [ ] First push to `main` after merge tags `v0.1.x`, builds image, pushes to `ghcr.io/grimvoodoo/dm-mcp:<tag>` and `:latest`.
- [ ] `docker pull ghcr.io/grimvoodoo/dm-mcp:latest` succeeds.
- [ ] `docker run --rm -p 3000:3000 -v dm-mcp-data:/data -e DMMCP_DB_PATH=/data/campaign.db ghcr.io/grimvoodoo/dm-mcp:latest` serves `/healthz` on :3000.
- [ ] `docker run --rm -i ghcr.io/grimvoodoo/dm-mcp:latest stdio` speaks MCP over stdin/stdout.
- [ ] GHCR package visibility is set as intended (public vs. private) after first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application is now available as a container image, exposing TCP port 3000 with a default runtime command and overridable container arguments.

* **Chores**
  * Added automated release workflow to compute versions, build and publish versioned container images, attach provenance/SBOM, tag releases, and publish changelogs.
  * Reduced Docker build context by excluding non-essential files to speed and slim container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->