### PR TITLE
security: Trivy secret scanning via pre-commit hook + CI workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-commit secret scan via Trivy. Blocks the commit if any staged file would
+# leak credentials, API keys, or other high-sensitivity strings.
+#
+# Enable per-clone with:
+#   git config core.hooksPath .githooks
+#
+# A matching CI job (.github/workflows/secret-scan.yaml) catches anything that
+# bypasses this hook (e.g. --no-verify, or a fresh clone without core.hooksPath
+# pointed here yet) so a leak still surfaces in the PR / push checks.
+
+set -euo pipefail
+
+if ! command -v trivy >/dev/null 2>&1; then
+    echo "pre-commit: trivy is not installed; cannot run the secret scan." >&2
+    echo "  Install: https://trivy.dev/latest/getting-started/installation/" >&2
+    echo "  Or download a binary from https://github.com/aquasecurity/trivy/releases" >&2
+    echo "  (no-soft-fail: hook fails closed so a missing scanner doesn't masquerade as a clean scan)" >&2
+    exit 1
+fi
+
+# List staged files: Added, Copied, Modified, Renamed. Skip Deleted (no content
+# to scan) and submodule changes. -z gives NUL-separated paths so spaces / odd
+# characters survive intact.
+staged_count=$(git diff --cached --name-only --diff-filter=ACMR -z | tr -cd '\0' | wc -c)
+if [ "$staged_count" = "0" ]; then
+    # Nothing relevant staged — let the commit proceed (e.g. amend with no changes).
+    exit 0
+fi
+
+# Materialise the indexed content into a temp dir. Using checkout-index instead
+# of just scanning the working tree means we scan exactly what's about to land
+# in the commit, ignoring any unstaged edits or untracked files.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+git diff --cached --name-only --diff-filter=ACMR -z \
+    | git checkout-index -z --stdin --prefix="$tmpdir/"
+
+if ! trivy fs --scanners secret --exit-code 1 --quiet "$tmpdir"; then
+    echo >&2
+    echo "pre-commit: trivy detected secrets in staged content. Commit blocked." >&2
+    echo "Review the findings above. To override (last resort — the CI scan will" >&2
+    echo "still flag it), re-run with: git commit --no-verify" >&2
+    echo "False positive? Add an exception to .trivyignore and re-stage." >&2
+    exit 1
+fi

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,52 @@
+name: Secret Scan
+
+# Runs Trivy's secret scanner against the working tree on every push and PR.
+# This is the safety net — the .githooks/pre-commit hook catches most leaks
+# locally before a push, but a missing local hook (fresh clone, --no-verify
+# override) will still be caught here in time to rotate the credential.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same branch when a new push arrives — same
+# pattern as ci.yaml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-secret-scan:
+    name: Trivy Secret Scan
+    runs-on: arc-runner-dm-mcp
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # The action downloads its own trivy binary (no apt-get needed). We pin
+      # to a major version so renovate-style bumps are auditable.
+      - name: Run Trivy filesystem secret scanner
+        uses: aquasecurity/trivy-action@0.x
+        with:
+          scan-type: fs
+          scanners: secret
+          # Fail the job on findings — the whole point of the workflow.
+          exit-code: '1'
+          # Trivy classifies all secret findings as CRITICAL or HIGH; this
+          # filter discards low-confidence noise from other scanners that
+          # might creep in if `scanners` is expanded later.
+          severity: 'HIGH,CRITICAL'
+          # Don't waste CI on the build artefact tree or vendored content
+          # if those ever land. Leaving the list short — extend with a
+          # comment naming the file and reason if a false positive lands.
+          skip-dirs: target
+          # Quiet startup banner; keep findings prominent.
+          hide-progress: true

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -31,10 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # The action downloads its own trivy binary (no apt-get needed). We pin
-      # to a major version so renovate-style bumps are auditable.
+      # The action downloads its own trivy binary (no apt-get needed). Pinned
+      # to a specific release — aquasecurity/trivy-action doesn't publish a
+      # floating major-version tag, so we pin to v0.36.0 and bump explicitly.
       - name: Run Trivy filesystem secret scanner
-        uses: aquasecurity/trivy-action@0.x
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scanners: secret

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ cargo build --release
 
 Pure Rust, rustls-only TLS — the release binary is statically linked and ships into a `scratch` container with no system dependencies.
 
+## Development setup
+
+Enable the Trivy secret-scan pre-commit hook (one-time per clone):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook (`.githooks/pre-commit`) runs `trivy fs --scanners secret` against the staged content before each commit and blocks the commit if it finds a leak. It requires `trivy` on `PATH`; install from <https://trivy.dev/latest/getting-started/installation/> or grab a binary from the [releases page](https://github.com/aquasecurity/trivy/releases). The same scan also runs in CI (`.github/workflows/secret-scan.yaml`) on every push and PR, so an accidental bypass still surfaces in time to rotate the credential.
+
 ## Run
 
 ```bash


### PR DESCRIPTION
## Summary

Two layers of defence against accidentally committing credentials to a public repo:

1. **Pre-commit hook** — `.githooks/pre-commit` runs `trivy fs --scanners secret` on the indexed content before each commit. Blocks the commit if a finding lands.
2. **CI workflow** — `.github/workflows/secret-scan.yaml` runs the same scanner on every push (any branch) and PR against main. Catches anything that bypasses the local hook (fresh clone without `core.hooksPath` set, `--no-verify`, missing local trivy).

## Why two layers

- The local hook gives the right ergonomics — block before push, before the credential is in any remote at all.
- The CI scan is the safety net. Public repo, so even a momentary leak in a feature branch needs to be caught in time to rotate. The CI scan firing on push (not just PR) shortens that window.

## Design choices worth flagging

- **Hook scans indexed content, not the working tree.** Uses `git checkout-index` into a tempdir so unstaged edits and untracked files don't pollute results. Means the hook scans exactly what would land in the commit.
- **Hook hard-fails if `trivy` isn't installed**, with install instructions in the message. Soft-failing would let a missing scanner masquerade as a clean scan — the worst possible UX for a security control.
- **Activation is opt-in per clone** via `git config core.hooksPath .githooks` (git can't ship hooks automatically). Documented in README's new "Development setup" section. The CI scan runs unconditionally, so an unconfigured clone is still covered server-side.
- **Severity filter `HIGH,CRITICAL`** in CI — trivy's secret findings are universally CRITICAL anyway, so the filter is forward-compat for if the workflow ever expands `scanners: secret,vuln,...`.

## Verification

Tested locally by planting a fabricated AWS access key (non-allowlisted, distinct from the famous `AKIAIOSFODNN7EXAMPLE` doc value) in a test file:

```
fake_leak.txt (secrets)
=======================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 1)

CRITICAL: AWS (aws-access-key-id)
════════════════════════════════════════
AWS Access Key ID
────────────────────────────────────────
 fake_leak.txt:3 (offset: 150 bytes)
```

Commit was blocked. Removed the fake file, re-staged the real changes (hook + workflow + README) — hook re-ran clean and the commit landed.

## Test plan

- [x] Hook blocks a planted fake AWS key and prints an actionable error message
- [x] Hook passes a clean commit (this PR's own commit)
- [x] Hook executable bit set (`100755`)
- [ ] CI `Trivy Secret Scan` job runs on this PR and passes
- [ ] (Manual, post-merge) Verify the workflow also fires on direct pushes to a non-PR branch

## Follow-ups not in this PR

- Consider a `.trivyignore` if any false positives surface (none currently)
- Could add a `make secret-scan` target that runs the same scan on demand — useful when investigating a hook block

🤖 Generated with [Claude Code](https://claude.com/claude-code)