### PR TITLE
world: seed zone knowledge on character placement and travel (fixes #15, #16)

### DIFF
--- a/src/characters.rs
+++ b/src/characters.rs
@@ -298,6 +298,21 @@ pub fn create(conn: &mut Connection, p: CreateParams) -> Result<CreateResult> {
         )
         .context("insert characters row")?;
         let id = tx.last_insert_rowid();
+
+        // Seed knowledge of the starting zone. A character placed at a zone "knows"
+        // they are there — without this, world.describe_zone refuses to describe the
+        // character's own current location and world.map can't anchor at it.
+        // Order-independent with setup.mark_ready: both upsert visited, idempotently.
+        if let Some(zone_id) = p.current_zone_id {
+            tx.execute(
+                "INSERT INTO character_zone_knowledge
+                    (character_id, zone_id, level, last_visit_at_hour)
+                 VALUES (?1, ?2, 'visited', 0)
+                 ON CONFLICT(character_id, zone_id) DO UPDATE SET level = 'visited'",
+                params![id, zone_id],
+            )
+            .context("seed character knowledge of starting zone")?;
+        }
         tx.commit().context("commit create tx")?;
         id
     };

--- a/src/world.rs
+++ b/src/world.rs
@@ -161,7 +161,7 @@ pub fn travel(conn: &mut Connection, p: TravelParams) -> Result<TravelResult> {
     )
     .context("update character.current_zone_id")?;
 
-    // 2. character_zone_knowledge upsert to 'visited'.
+    // 2. character_zone_knowledge upsert to 'visited' for the destination.
     upsert_knowledge_tx(
         &tx,
         p.character_id,
@@ -170,8 +170,37 @@ pub fn travel(conn: &mut Connection, p: TravelParams) -> Result<TravelResult> {
         hour_after,
     )?;
 
+    // 2b. Defensive: also bump the origin to 'visited'. The character was just there,
+    // so they know it. Normally character.create has already seeded this; this catches
+    // the edge case where it wasn't (e.g. legacy data, non-API insertion).
+    upsert_knowledge_tx(
+        &tx,
+        p.character_id,
+        from_zone_id,
+        KnowledgeLevel::Visited,
+        hour_before,
+    )?;
+
     // 3. Stub-gen any missing neighbours of the destination zone.
     let stubs_generated = ensure_stub_neighbours_tx(&tx, p.to_zone_id)?;
+
+    // 3b. Mark every neighbour of the destination as at least 'rumored' so the map can
+    // show the player their next-move options. Includes any stubs just generated above.
+    // upsert_knowledge_tx is monotonic — if the player already knew a neighbour better
+    // than rumored, the existing level is preserved.
+    let dest_neighbours: Vec<i64> = read_outgoing_edges(&tx, p.to_zone_id)?
+        .into_iter()
+        .map(|e| e.to_zone_id)
+        .collect();
+    for nzid in dest_neighbours {
+        upsert_knowledge_tx(
+            &tx,
+            p.character_id,
+            nzid,
+            KnowledgeLevel::Rumored,
+            hour_after,
+        )?;
+    }
 
     // 4. First-visit landmark generation.
     let landmarks_generated = if first_visit {
@@ -241,6 +270,18 @@ pub fn map(conn: &Connection, p: MapParams) -> Result<MapResult> {
     // BFS from origin assigning grid positions. Limit BFS to known zones (rumored or
     // better) so unknown zones don't leak into the map.
     let known: BTreeMap<i64, String> = read_known_zone_levels(conn, p.character_id)?;
+    if !known.contains_key(&origin_zone_id) {
+        // Strict knowledge check — symmetric with describe_zone. character.create seeds
+        // 'visited' for the starting zone and travel tops it up, so this is unreachable
+        // in normal API use. If it does fire, the data is inconsistent and silently
+        // returning a map where origin is 'rumored' (the prior fallback) hides the bug.
+        bail!(
+            "character {} has no knowledge of their current zone {} \
+             (data inconsistency — character.create / world.travel should have seeded this)",
+            p.character_id,
+            origin_zone_id
+        );
+    }
     let mut positions: BTreeMap<i64, (i32, i32)> = BTreeMap::new();
     positions.insert(origin_zone_id, (0, 0));
 
@@ -269,7 +310,12 @@ pub fn map(conn: &Connection, p: MapParams) -> Result<MapResult> {
     // Hydrate the zone payloads.
     let mut zones = Vec::new();
     for (zid, (x, y)) in positions {
-        let level = known.get(&zid).cloned().unwrap_or_else(|| "rumored".into());
+        // BFS only inserts zones present in `known` (origin is gated by the bail above,
+        // expansion checks `known.contains_key` per neighbour), so this lookup never misses.
+        let level = known
+            .get(&zid)
+            .cloned()
+            .expect("BFS only walks zones in `known`");
         let row: (String, String, String) = conn.query_row(
             "SELECT name, biome, kind FROM zones WHERE id = ?1",
             [zid],
@@ -754,13 +800,8 @@ mod tests {
         )
         .unwrap()
         .character_id;
-        // Mark starting zone as visited for the player up-front so it appears on the map.
-        conn.execute(
-            "INSERT INTO character_zone_knowledge (character_id, zone_id, level)
-             VALUES (?1, ?2, 'visited')",
-            params![player, gw.starting_zone_id],
-        )
-        .unwrap();
+        // characters::create now seeds 'visited' knowledge of the starting zone as part
+        // of the same transaction — no manual upsert needed here.
         (player, gw.neighbour_zone_ids, gw.starting_zone_id)
     }
 

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -213,6 +213,132 @@ async fn travel_to_neighbour_advances_clock_and_fog_and_map() -> Result<()> {
     Ok(())
 }
 
+// ── Regression tests for issue #15 (knowledge seeding) and #16 (map/describe parity)
+
+#[tokio::test]
+async fn character_create_seeds_visited_knowledge_for_starting_zone() -> Result<()> {
+    // #15 symptom 1: character.create with current_zone_id used to leave the player
+    // unable to describe their own current zone. After the fix, a freshly-created
+    // character can immediately describe_zone for where they are.
+    let h = connect().await?;
+    let (player, starting, _neighbours) = bootstrap(&h.client).await?;
+
+    let r = call(
+        &h.client,
+        "world.describe_zone",
+        serde_json::json!({ "character_id": player, "zone_id": starting }),
+    )
+    .await?;
+    assert_eq!(
+        r["knowledge_level"].as_str(),
+        Some("visited"),
+        "character.create with current_zone_id should seed visited knowledge"
+    );
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn travel_seeds_origin_knowledge_so_describe_works_for_back_edge() -> Result<()> {
+    // #15 symptom 2: world.travel only upserted the destination. After a 1→2 hop the
+    // player could no longer describe zone 1 (back-edge). The fix also upserts the
+    // origin defensively. Combined with the character.create seeding above, this
+    // closes the symptom even for legacy data without the create-time seeding.
+    let h = connect().await?;
+    let (player, starting, neighbours) = bootstrap(&h.client).await?;
+    let target = neighbours[0];
+
+    call(
+        &h.client,
+        "world.travel",
+        serde_json::json!({ "character_id": player, "to_zone_id": target }),
+    )
+    .await?;
+
+    // After travelling to target, the player should still be able to describe the
+    // zone they came from.
+    let r = call(
+        &h.client,
+        "world.describe_zone",
+        serde_json::json!({ "character_id": player, "zone_id": starting }),
+    )
+    .await?;
+    assert_eq!(r["knowledge_level"].as_str(), Some("visited"));
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn travel_seeds_destination_neighbours_as_rumored_for_map_visibility() -> Result<()> {
+    // #15 symptom 3: after travelling 1→2, world.map showed zone 2 with zero
+    // connections, even though zone 2 had real edges to {1, plus stub neighbours}.
+    // The fix marks every neighbour of the destination as at least 'rumored' so the
+    // map can show next-move options.
+    let h = connect().await?;
+    let (player, starting, neighbours) = bootstrap(&h.client).await?;
+    let target = neighbours[0];
+
+    call(
+        &h.client,
+        "world.travel",
+        serde_json::json!({ "character_id": player, "to_zone_id": target }),
+    )
+    .await?;
+
+    let m = call(
+        &h.client,
+        "world.map",
+        serde_json::json!({ "character_id": player }),
+    )
+    .await?;
+    let zones = m["zones"].as_array().unwrap();
+    let zone_ids: Vec<i64> = zones.iter().map(|z| z["id"].as_i64().unwrap()).collect();
+
+    // Player is at target. Map must show:
+    //  - target itself (visited, origin),
+    //  - starting (visited, came from there),
+    //  - the back-edge connection (verified in the older travel test).
+    assert!(
+        zone_ids.contains(&target),
+        "map must include target (origin); got {zone_ids:?}"
+    );
+    assert!(
+        zone_ids.contains(&starting),
+        "map must include starting (back-edge — was visited en route); got {zone_ids:?}"
+    );
+
+    // Plus: target had stub neighbours generated during travel (because target was a
+    // stub leaf with only the back-edge before). Those should now be 'rumored' on the
+    // map, not invisible.
+    let conns = m["connections"].as_array().unwrap();
+    let outgoing_from_target: Vec<i64> = conns
+        .iter()
+        .filter_map(|c| {
+            let from = c["from_zone_id"].as_i64()?;
+            let to = c["to_zone_id"].as_i64()?;
+            (from == target).then_some(to)
+        })
+        .collect();
+    assert!(
+        outgoing_from_target.len() >= 2,
+        "target should expose its back-edge to starting plus at least one new stub \
+         neighbour as a connection on the map; got connections {conns:?}"
+    );
+
+    // Every zone listed on the map must have a knowledge_level (not absent or null):
+    // verifies #16 — map and describe agree on the knowledge predicate.
+    for z in zones {
+        let lvl = z["knowledge_level"].as_str().unwrap_or("");
+        assert!(
+            ["rumored", "known", "visited", "mapped"].contains(&lvl),
+            "every map zone must have a real knowledge level; got {z:?}"
+        );
+    }
+
+    h.client.cancel().await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn world_tools_are_listed() -> Result<()> {
     let h = connect().await?;


### PR DESCRIPTION
Fixes #15.
Fixes #16.

## Symptoms

Three places in the knowledge-seeding pipeline weren't writing rows to `character_zone_knowledge`:

1. **`character.create`** with `current_zone_id` — fresh character couldn't describe their own zone (`world.describe_zone` refused with "no knowledge of zone N"). The path that *did* seed (via `setup.mark_ready`) only worked when both player_character_id AND a starting zone were known at mark-ready time, so the create-then-mark-ready ordering was unprotected.
2. **`world.travel` (back-edge)** — after travelling 1→2, the player could no longer describe zone 1. Travel only upserted the destination, not the origin.
3. **`world.travel` (forward neighbours)** — `world.map` after travel showed the destination with **zero connections**, even though it had real `zone_connections` rows pointing to {origin, plus stub neighbours}. The strict knowledge filter blanked them all because travel didn't seed even rumored knowledge for them.

A related inconsistency surfaced as #16: `world.map` silently defaulted any zone outside `known` to `knowledge_level: "rumored"` (via `unwrap_or_else`), while `world.describe_zone` was strict. With the seeding fixed, the silent fallback becomes both unreachable and dishonest — removed.

## Fix

- **`characters::create`** — when `current_zone_id` is `Some(z)`, upsert `'visited'` knowledge for `z` inside the same transaction as the character row. Idempotent with `setup.mark_ready`'s existing seeding (both use upsert).
- **`world::travel`** — also upserts `'visited'` for the origin (defensive — covers legacy data without create-time seed) and `'rumored'` for every neighbour of the destination (including stubs just generated). `upsert_knowledge_tx` is monotonic so this never downgrades existing knowledge.
- **`world::map`** — bail with a diagnostic if origin has no knowledge row (was: silently substituted `'rumored'`). With the seeding fix, this is unreachable in normal API use; if it does fire, the data inconsistency surfaces as a visible error rather than masquerading as valid output.

## Tests

Three new e2e regression tests in `tests/world.rs`, each mapping to one symptom:

- `character_create_seeds_visited_knowledge_for_starting_zone`
- `travel_seeds_origin_knowledge_so_describe_works_for_back_edge`
- `travel_seeds_destination_neighbours_as_rumored_for_map_visibility`

The third also asserts every zone on the map carries one of the four real knowledge levels (no nulls / phantoms) — covers #16.

Removed a redundant manual `INSERT INTO character_zone_knowledge … 'visited'` from the inline `bootstrap_world` test in `src/world.rs` — it now collides on PK with the create-time seed.

## Test plan

- [x] `cargo test --tests` — all 12 binaries pass, including 3 new regression tests
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests fail without the fix (verified mentally by inspection — the assertions exactly mirror the issue repros)
- [ ] Manual MCP walkthrough of the original symptom in #15 (can rerun the live session if you want)

🤖 Generated with [Claude Code](https://claude.com/claude-code)