### PR TITLE
characters: surface full condition shape on character.get (fixes #18)

### DIFF
--- a/src/characters.rs
+++ b/src/characters.rs
@@ -205,6 +205,15 @@ pub struct ConditionRow {
     pub id: i64,
     pub condition: String,
     pub severity: i32,
+    /// Event id of whatever caused this condition, if the application call chained one.
+    pub source_event_id: Option<i64>,
+    /// Optional in-game-hour expiry (decremented at hour-time, not round-time).
+    pub expires_at_hour: Option<i64>,
+    /// Optional round-based expiry. Ticked by `combat.next_turn` at round boundaries.
+    pub expires_after_rounds: Option<i32>,
+    /// Optional save-on-retry spec (e.g. `save:con:dc15`). The DM agent reads this to
+    /// know whether the character can attempt a periodic save to throw the condition off.
+    pub remove_on_save: Option<String>,
 }
 
 // ── Implementation ────────────────────────────────────────────────────────────
@@ -687,8 +696,13 @@ fn load_resources(conn: &Connection, character_id: i64) -> Result<Vec<ResourceRo
 }
 
 fn load_active_conditions(conn: &Connection, character_id: i64) -> Result<Vec<ConditionRow>> {
+    // Surface every optional field stored on character_conditions, mirroring how
+    // load_active_effects exposes effects' full shape. Without this, fields like
+    // remove_on_save are write-only — the DM agent can apply a condition with a save
+    // spec but can never read it back to know the spec exists.
     let mut stmt = conn.prepare(
-        "SELECT id, condition, severity
+        "SELECT id, condition, severity,
+                source_event_id, expires_at_hour, expires_after_rounds, remove_on_save
          FROM character_conditions
          WHERE character_id = ?1 AND active = 1
          ORDER BY id",
@@ -699,6 +713,10 @@ fn load_active_conditions(conn: &Connection, character_id: i64) -> Result<Vec<Co
                 id: row.get(0)?,
                 condition: row.get(1)?,
                 severity: row.get(2)?,
+                source_event_id: row.get(3)?,
+                expires_at_hour: row.get(4)?,
+                expires_after_rounds: row.get(5)?,
+                remove_on_save: row.get(6)?,
             })
         })?
         .collect::<rusqlite::Result<_>>()?;

--- a/tests/character_core.rs
+++ b/tests/character_core.rs
@@ -452,3 +452,118 @@ async fn proficiency_and_resource_crud() -> Result<()> {
     h.client.cancel().await?;
     Ok(())
 }
+
+// ── Regression test for issue #18 (character.get truncates condition fields) ──
+
+#[tokio::test]
+async fn character_get_surfaces_full_condition_shape() -> Result<()> {
+    // Conditions are stored with optional fields (remove_on_save, expires_after_rounds,
+    // expires_at_hour, source_event_id). Pre-fix, character.get only returned id /
+    // condition / severity, making remove_on_save effectively write-only — the DM
+    // agent could apply a condition with a save-on-retry spec but never read the spec
+    // to know it existed.
+    //
+    // After the fix, every stored field appears on the response, mirroring how
+    // active_effects already exposes its full schema.
+    let h = connect().await?;
+    let cr = call(
+        &h.client,
+        "character.create",
+        serde_json::json!({
+            "name": "Hexed",
+            "role": "player",
+            "str_score": 10, "dex_score": 10, "con_score": 10,
+            "int_score": 10, "wis_score": 10, "cha_score": 10
+        }),
+    )
+    .await?;
+    let cid = cr["character_id"].as_i64().unwrap();
+
+    // (1) Apply with a remove_on_save spec and a non-default severity.
+    call(
+        &h.client,
+        "condition.apply",
+        serde_json::json!({
+            "character_id": cid,
+            "condition": "poisoned",
+            "severity": 1,
+            "remove_on_save": "save:con:dc15"
+        }),
+    )
+    .await?;
+
+    // (2) Apply with an expires_after_rounds countdown.
+    call(
+        &h.client,
+        "condition.apply",
+        serde_json::json!({
+            "character_id": cid,
+            "condition": "frightened",
+            "expires_after_rounds": 5
+        }),
+    )
+    .await?;
+
+    let view = call(
+        &h.client,
+        "character.get",
+        serde_json::json!({ "character_id": cid }),
+    )
+    .await?;
+    let conds = view["active_conditions"].as_array().unwrap();
+    assert_eq!(
+        conds.len(),
+        2,
+        "both conditions should be active; got {conds:?}"
+    );
+
+    let poisoned = conds
+        .iter()
+        .find(|c| c["condition"] == "poisoned")
+        .context("poisoned condition")?;
+    assert_eq!(
+        poisoned["remove_on_save"].as_str(),
+        Some("save:con:dc15"),
+        "remove_on_save must be surfaced on character.get; got {poisoned:?}"
+    );
+    // Optional time-bound fields not set on this condition must serialise as null
+    // (key present, value null), not be absent from the JSON.
+    for absent in ["expires_after_rounds", "expires_at_hour"] {
+        assert!(
+            poisoned.get(absent).is_some_and(serde_json::Value::is_null),
+            "{absent} should be present and null on poisoned; got {poisoned:?}"
+        );
+    }
+    // source_event_id is auto-populated with the condition.applied event id by the
+    // engine — it's the chain pointer back to "what caused this". Just assert it's
+    // a positive integer here; the exact value depends on event ordering in the run.
+    assert!(
+        poisoned["source_event_id"].as_i64().is_some_and(|v| v > 0),
+        "source_event_id should be the apply event's id; got {poisoned:?}"
+    );
+
+    let frightened = conds
+        .iter()
+        .find(|c| c["condition"] == "frightened")
+        .context("frightened condition")?;
+    assert_eq!(
+        frightened["expires_after_rounds"].as_i64(),
+        Some(5),
+        "expires_after_rounds must be surfaced; got {frightened:?}"
+    );
+    assert!(
+        frightened
+            .get("remove_on_save")
+            .is_some_and(serde_json::Value::is_null),
+        "remove_on_save should be present and null on frightened; got {frightened:?}"
+    );
+    assert!(
+        frightened
+            .get("expires_at_hour")
+            .is_some_and(serde_json::Value::is_null),
+        "expires_at_hour should be present and null on frightened; got {frightened:?}"
+    );
+
+    h.client.cancel().await?;
+    Ok(())
+}


### PR DESCRIPTION
Fixes #18.

## Symptom

`condition.apply` accepts and stores four optional fields:

- `source_event_id`
- `expires_at_hour`
- `expires_after_rounds`
- `remove_on_save` (e.g. `save:con:dc15`)

These are honored internally — confirmed by the existing
`condition_with_expires_after_rounds_decrements_on_round_wrap` e2e test,
which proves the round-tick mechanic reads `expires_after_rounds` correctly.

But `character.get`'s `active_conditions` array only returned `id`,
`condition`, and `severity`. The most user-visible casualty:
`remove_on_save` was effectively write-only — a DM agent could apply a
condition with a periodic save spec but had no way to read the spec
back, defeating the entire point.

`active_effects` already surfaces its full schema (with `expires_at_hour`,
`expires_after_rounds`, `expires_on_dispel` returned even when null).
The conditions read path was inconsistent.

## Fix

Two changes in `src/characters.rs`:

1. **`ConditionRow`** gains four `Option<…>` fields, mirroring how
   `EffectRow` exposes its full storage shape.
2. **`load_active_conditions`** selects all seven columns and populates
   them.

No write-side changes — the columns were already being persisted.

## Regression test

`tests/character_core.rs::character_get_surfaces_full_condition_shape`
applies two conditions:

- `poisoned` with `remove_on_save: "save:con:dc15"`
- `frightened` with `expires_after_rounds: 5`

…then asserts:

- `remove_on_save` lands as a string on poisoned and as `null` (not absent)
  on frightened.
- `expires_after_rounds` lands as `5` on frightened, `null` on poisoned.
- `expires_at_hour` lands as `null` (key present) on both.
- `source_event_id` is auto-populated by the engine with the
  `condition.applied` event id — surfaced as a positive int. Test asserts
  the integer-ness rather than an exact value, since event ordering varies.

The `null`-not-absent assertion is the load-bearing one: confirms the
JSON serialization uses Option<T> rather than `#[serde(skip_serializing_if)]`,
so the field is always discoverable by an LLM consumer.

## Test plan

- [x] `cargo test --tests` — 13 binaries, 161 tests, all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New regression test fails without the fix (verified mentally — `load_active_conditions` only selected 3 columns pre-fix; `as_str()` on the missing key would return `None`, failing the `Some("save:con:dc15")` assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Character condition queries now return complete metadata including source event details, expiration information, and removal specifications instead of truncated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->