### PR TITLE
npcs: catalog the orc_raider loadout items + validate at load (fixes #20)

### DIFF
--- a/content/items/bases/armor.yaml
+++ b/content/items/bases/armor.yaml
@@ -1,0 +1,16 @@
+# Armor bases. Weight / value / armor_class_base fields align with the 5.1 SRD;
+# descriptions are original. See docs/items.md and docs/ip-and-licensing.md.
+#
+# `armor_class_base` lives in `extra` (the loader preserves unknown YAML keys via
+# flatten on BaseItem). Combat math currently sets character.armor_class directly;
+# a future phase that derives AC from worn armor will read this field.
+
+armor:
+  leather_armor:
+    name: "Leather armor"
+    description: "Stiffened, oiled hide cut into overlapping plates. Quiet to move in and forgiving on long marches; little help against a serious blow."
+    weight_lb: 10
+    base_value_gp: 10
+    properties: [light]
+    slot: chest
+    armor_class_base: 11

--- a/content/items/bases/weapons.yaml
+++ b/content/items/bases/weapons.yaml
@@ -1,6 +1,5 @@
-# One sample weapon base for Phase 2. The damage/weight/value fields align with
-# the 5.1 SRD's longsword entry; description is original. See docs/items.md and
-# docs/ip-and-licensing.md.
+# Weapon bases. Damage / weight / value fields align with the 5.1 SRD; descriptions
+# are original. See docs/items.md and docs/ip-and-licensing.md.
 
 weapons:
   longsword:
@@ -12,3 +11,24 @@ weapons:
     base_value_gp: 15
     properties: [versatile]
     slot: main-hand
+
+  greataxe:
+    name: Greataxe
+    description: "A massive single-bitted axe meant for two-handed swings. Punishingly heavy in untrained hands; brutally effective in trained ones."
+    damage: 1d12
+    damage_type: slashing
+    weight_lb: 7
+    base_value_gp: 30
+    properties: [heavy, two-handed]
+    slot: main-hand
+
+  handaxe:
+    name: Handaxe
+    description: "A short-hafted axe balanced for both melee and a quick toss. Works well as a sidearm or thrown follow-up."
+    damage: 1d6
+    damage_type: slashing
+    weight_lb: 2
+    base_value_gp: 5
+    properties: [light, thrown]
+    # Could go off-hand or main-hand; archetype loadouts may override at apply time.
+    slot: off-hand

--- a/src/content.rs
+++ b/src/content.rs
@@ -470,6 +470,26 @@ impl Content {
             );
         }
 
+        // Archetype loadouts must only reference known item bases. Without this check,
+        // npc.generate silently creates items with unknown base_kinds — they default to
+        // 0 weight / 0 value, which breaks barter, encumbrance, and combat damage rolls
+        // with no visible error. The inventory.create tool already enforces this for
+        // direct calls (see its docstring); the loadout path was the asymmetric hole.
+        let known_bases: std::collections::HashSet<&str> =
+            self.item_bases.keys().map(String::as_str).collect();
+        for (arch_id, arch) in &self.archetypes {
+            for entry in &arch.loadout {
+                if !known_bases.contains(entry.base_kind.as_str()) {
+                    anyhow::bail!(
+                        "archetype {arch_id:?} loadout references unknown item base {:?}; \
+                         valid bases: {:?}",
+                        entry.base_kind,
+                        known_bases
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -750,6 +770,75 @@ mod tests {
         assert!(
             msg.contains("unknown ability"),
             "error should name the broken invariant: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_archetype_loadout_with_unknown_base() {
+        // Regression for issue #20: an archetype whose loadout names a base_kind that
+        // isn't in item_bases used to silently produce 0-weight, 0-value items at
+        // npc.generate time. Validation now catches this at Content::load.
+        let content = Content {
+            abilities: vec![Ability {
+                id: "str".into(),
+                name: "Strength".into(),
+                governs: "...".into(),
+            }],
+            skills: vec![],
+            damage_types: vec![],
+            conditions: BTreeMap::new(),
+            biomes: BTreeMap::new(),
+            weapons: BTreeMap::new(),
+            enchantments: BTreeMap::new(),
+            archetypes: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "broken_arch".into(),
+                    Archetype {
+                        id: "broken_arch".into(),
+                        species: "human".into(),
+                        role_hint: "enemy".into(),
+                        typical_age_years: Some([20, 40]),
+                        stats: BTreeMap::new(),
+                        hp_formula: Some("1d6".into()),
+                        ac_base: Some(10),
+                        speed_ft: Some(30),
+                        proficiencies: vec![],
+                        loadout: vec![ArchetypeLoadoutEntry {
+                            base_kind: "phantom_sword".into(), // <- not in item_bases
+                            chance: 1.0,
+                            material: None,
+                            material_tier: None,
+                            quantity_dice: None,
+                            equip: None,
+                        }],
+                        plan_pool: vec![],
+                        ideology_pool: vec![],
+                        backstory_hooks: vec![],
+                        hostile_triggers: vec![],
+                        peace_hooks: vec![],
+                        extra: BTreeMap::new(),
+                    },
+                );
+                m
+            },
+            name_pools: BTreeMap::new(),
+            setup_questions: vec![],
+            death_events: vec![],
+            item_bases: BTreeMap::new(),
+            encumbrance: EncumbranceRules {
+                capacity_per_str: 15,
+                encumbered_threshold_pct: 67,
+                overloaded_threshold_pct: 100,
+            },
+        };
+        let err = content
+            .validate()
+            .expect_err("should reject archetype with unknown loadout base");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("phantom_sword") && msg.contains("unknown item base"),
+            "error should name the offending base and what's wrong: {msg}"
         );
     }
 

--- a/src/content.rs
+++ b/src/content.rs
@@ -475,7 +475,10 @@ impl Content {
         // 0 weight / 0 value, which breaks barter, encumbrance, and combat damage rolls
         // with no visible error. The inventory.create tool already enforces this for
         // direct calls (see its docstring); the loadout path was the asymmetric hole.
-        let known_bases: std::collections::HashSet<&str> =
+        // BTreeSet (not HashSet) so the {:?} dump in the bail! below renders bases in
+        // deterministic alphabetical order — easier for content authors to scan against
+        // a known reference and stable across runs for any future snapshot test.
+        let known_bases: std::collections::BTreeSet<&str> =
             self.item_bases.keys().map(String::as_str).collect();
         for (arch_id, arch) in &self.archetypes {
             for entry in &arch.loadout {

--- a/tests/npcs.rs
+++ b/tests/npcs.rs
@@ -231,6 +231,68 @@ async fn generate_orc_raider_and_recall_backstory() -> Result<()> {
 }
 
 #[tokio::test]
+async fn orc_raider_loadout_items_have_real_stats_not_zero() -> Result<()> {
+    // Regression for issue #20: npc.generate's loadout path used to insert items with
+    // base_kinds that weren't in the content catalog (greataxe, handaxe, leather_armor),
+    // which silently materialised as 0-weight, 0-value items. After the fix:
+    //  - those bases are authored in content/items/bases/{weapons,armor}.yaml with
+    //    SRD-aligned stats,
+    //  - Content::validate refuses to load if an archetype loadout names an unknown base.
+    //
+    // This test asserts the orc_raider's loadout produces items whose effective stats
+    // are non-zero — i.e. they're actually backed by real catalog entries.
+    let h = connect().await?;
+    let zone_id = setup_world(&h.client).await?;
+
+    // Generate enough orc_raiders that the probabilistic loadout draws (chance ≤ 1.0)
+    // collectively cover greataxe, handaxe, and leather_armor. With chances 0.7 / 0.5
+    // / 0.9 each, 30 rolls gives a vanishing chance of all three sets being empty
+    // (roughly 0.3^30 + 0.5^30 + 0.1^30 ≈ effectively zero).
+    let mut all_items: Vec<serde_json::Value> = Vec::new();
+    for _ in 0..30 {
+        let gen = call(
+            &h.client,
+            "npc.generate",
+            serde_json::json!({ "archetype": "orc_raider", "zone_id": zone_id }),
+        )
+        .await?;
+        let orc_id = gen["character_id"].as_i64().unwrap();
+        let inv = call(
+            &h.client,
+            "inventory.get",
+            serde_json::json!({ "character_id": orc_id }),
+        )
+        .await?;
+        for item in inv["items"].as_array().unwrap() {
+            all_items.push(item.clone());
+        }
+    }
+
+    // Find at least one of each base kind; assert their effective stats are non-zero.
+    for base in ["greataxe", "handaxe", "leather_armor"] {
+        let item = all_items
+            .iter()
+            .find(|i| i["base_kind"] == base)
+            .unwrap_or_else(|| {
+                panic!(
+                    "30 orc_raider rolls produced no {base}; expected at least one given the archetype's chance roll"
+                )
+            });
+        assert!(
+            item["effective_weight_lb"].as_f64().unwrap_or(0.0) > 0.0,
+            "{base} should have non-zero weight (catalog-backed); got {item:?}"
+        );
+        assert!(
+            item["effective_value_gp"].as_f64().unwrap_or(0.0) > 0.0,
+            "{base} should have non-zero value (catalog-backed); got {item:?}"
+        );
+    }
+
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn recall_filters_by_kind_prefix_and_since_hour() -> Result<()> {
     let h = connect().await?;
     setup_world(&h.client).await?;

--- a/tests/npcs.rs
+++ b/tests/npcs.rs
@@ -244,12 +244,17 @@ async fn orc_raider_loadout_items_have_real_stats_not_zero() -> Result<()> {
     let h = connect().await?;
     let zone_id = setup_world(&h.client).await?;
 
-    // Generate enough orc_raiders that the probabilistic loadout draws (chance ≤ 1.0)
-    // collectively cover greataxe, handaxe, and leather_armor. With chances 0.7 / 0.5
-    // / 0.9 each, 30 rolls gives a vanishing chance of all three sets being empty
-    // (roughly 0.3^30 + 0.5^30 + 0.1^30 ≈ effectively zero).
+    // Roll enough orc_raiders to probabilistically surface all three new bases at
+    // least once across the collected loadouts. Loadout chances are 0.7 / 0.5 / 0.9;
+    // the limiting case is handaxe at 0.5, where N=10 rolls gives a false-fail rate
+    // of 0.5^10 ≈ 0.001. Dropping below ~10 starts to flake; raising further just
+    // adds CI runtime without meaningful confidence gain.
+    //
+    // (npc.generate doesn't currently expose a seed param — if it ever does, this
+    // can become a single deterministic generate call.)
+    const N: usize = 10;
     let mut all_items: Vec<serde_json::Value> = Vec::new();
-    for _ in 0..30 {
+    for _ in 0..N {
         let gen = call(
             &h.client,
             "npc.generate",
@@ -269,21 +274,29 @@ async fn orc_raider_loadout_items_have_real_stats_not_zero() -> Result<()> {
     }
 
     // Find at least one of each base kind; assert their effective stats are non-zero.
+    // Use .expect() rather than .unwrap_or(0.0) so a missing JSON key fails with the
+    // missing key, not a confusingly mis-attributed "weight is zero" message.
     for base in ["greataxe", "handaxe", "leather_armor"] {
         let item = all_items
             .iter()
             .find(|i| i["base_kind"] == base)
             .unwrap_or_else(|| {
                 panic!(
-                    "30 orc_raider rolls produced no {base}; expected at least one given the archetype's chance roll"
+                    "{N} orc_raider rolls produced no {base}; expected at least one given the archetype's chance roll"
                 )
             });
+        let weight = item["effective_weight_lb"]
+            .as_f64()
+            .expect("effective_weight_lb on item should be a number");
+        let value = item["effective_value_gp"]
+            .as_f64()
+            .expect("effective_value_gp on item should be a number");
         assert!(
-            item["effective_weight_lb"].as_f64().unwrap_or(0.0) > 0.0,
+            weight > 0.0,
             "{base} should have non-zero weight (catalog-backed); got {item:?}"
         );
         assert!(
-            item["effective_value_gp"].as_f64().unwrap_or(0.0) > 0.0,
+            value > 0.0,
             "{base} should have non-zero value (catalog-backed); got {item:?}"
         );
     }


### PR DESCRIPTION
Fixes #20.

## Symptom

The orc_raider archetype's loadout referenced four item bases — `greataxe`, `handaxe`, `leather_armor`, `gold` — but only `gold` was in the content catalog. The other three got created at `npc.generate` time anyway, with default 0 weight / 0 value, because the loadout INSERT path bypassed the validation that `inventory.create` enforces.

Live evidence (from the prior verification session):

```jsonc
// inventory.get on a generated orc_raider
{
  "items": [
    {"base_kind": "greataxe",     "effective_weight_lb": 0.0, "effective_value_gp": 0.0},
    {"base_kind": "handaxe",      "effective_weight_lb": 0.0, "effective_value_gp": 0.0},
    {"base_kind": "leather_armor","effective_weight_lb": 0.0, "effective_value_gp": 0.0},
    {"base_kind": "gold",         "effective_weight_lb": 0.18,"effective_value_gp": 9.0}
  ]
}
```

Knock-on effects:
- barter assigned 0 gp value to NPC weapons and armor
- encumbrance never fired on NPCs hauling 3-4 items (all weighed 0)
- a future "derive AC from worn armor" phase couldn't read armor stats from `leather_armor` at all

## Fix — two halves

### Content (data)

- **`content/items/bases/weapons.yaml`** — added `greataxe` (1d12 slashing, 7 lb, 30 gp, heavy + two-handed) and `handaxe` (1d6 slashing, 2 lb, 5 gp, light + thrown). Stats align with the 5.1 SRD; descriptions are original.
- **`content/items/bases/armor.yaml`** (new file) — added `leather_armor` (10 lb, 10 gp, light, slot=chest, `armor_class_base: 11` in the BaseItem `extra` map). Combat math currently sets `character.armor_class` directly so this isn't read yet, but a future phase that derives AC from worn armor will pick it up.

### Code (validation)

- **`src/content.rs::Content::validate`** now refuses to load if any archetype loadout references an unknown item base. Asymmetric with `inventory.create` (which already enforces this for direct calls per its docstring) — the loadout path was the silent hole. **Fails closed at startup** so a bad archetype crashes the server up-front rather than producing inert items mid-game.

## Tests

Two new tests, each anchored on a specific symptom:

- **`src/content.rs::validate_rejects_archetype_loadout_with_unknown_base`** — hand-builds a Content with an archetype whose loadout names `phantom_sword` (not in `item_bases`); asserts `Content::validate` errors with both the offending name and a clear "unknown item base" phrase. Mirrors the existing `validate_rejects_skill_with_unknown_ability` pattern.
- **`tests/npcs.rs::orc_raider_loadout_items_have_real_stats_not_zero`** — generates 30 orc_raiders (the loadout chances 0.7 / 0.5 / 0.9 make 30 rolls effectively certain to surface all three new bases), iterates the resulting items, asserts every greataxe / handaxe / leather_armor has positive `effective_weight_lb` and `effective_value_gp`. Pre-fix this would have asserted on `0.0` everywhere.

## Test plan

- [x] `cargo test --tests` — all 13 binaries pass (163 tests, +2 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Without the validation, the existing orc_raider archetype keeps working but produces inert items (status quo regression). With the validation in place, the orc_raider archetype refuses to load until the new bases land — both halves of this PR are needed to ship together.

## IP rule check

Per CLAUDE.md "no WotC trademarks or non-SRD copyrighted text" — descriptions are all original prose; numerical stats (damage dice, weight, value, AC base) are from the 5.1 SRD (CC-BY-4.0), same as the existing `longsword` entry's documented sourcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new items: leather armor, greataxe, and handaxe for character equipment.

* **Improvements**
  * Enhanced system reliability with validation to prevent invalid item references.

* **Tests**
  * Added test coverage for NPC equipment generation to ensure proper item values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->