### PR TITLE
npcs: substitute backstory placeholders from per-archetype slot pools (fixes #19)

### DIFF
--- a/content/npcs/archetypes/orc_raider.yaml
+++ b/content/npcs/archetypes/orc_raider.yaml
@@ -61,3 +61,53 @@ backstory_hooks:
   - "Fled from ${stronger_foe} after losing the duel"
   - "Was exiled from ${tribe} for breaking a sacred law"
   - "Carries a trophy taken from ${victim} at ${place}"
+
+# Substitution pools for the ${slot} placeholders above. ${years_ago} is reserved —
+# the engine fills it with a random integer 1..=50. Every other slot referenced in
+# backstory_hooks must appear here or Content::validate refuses to load.
+# Original prose, no SRD/WotC references.
+slot_pools:
+  settlement:
+    - "Ashbrook"
+    - "Westfen"
+    - "Stoneford"
+    - "Hollow Hill"
+    - "Pine-Reach"
+  oppressor:
+    - "the iron-cloaks"
+    - "the river barons"
+    - "a settler band"
+    - "the southern lord"
+    - "the thane's huntsmen"
+  past_wrong_against_orcs:
+    - "burned the granary"
+    - "broke the salt-treaty"
+    - "hanged a clan-elder"
+    - "defiled the bone-grove"
+  enemy_archetype:
+    - "a settler scout"
+    - "a hunter from the southern woods"
+    - "a river-trader's hired blade"
+    - "a southern soldier in iron"
+  cause:
+    - "a stolen blade"
+    - "an insult to the war-chief"
+    - "a debt of blood"
+    - "a broken oath"
+  stronger_foe:
+    - "a knight in iron"
+    - "a war-shaman of a rival clan"
+    - "a ranger of the royal woods"
+  tribe:
+    - "the Black-Pine clan"
+    - "the Red-Tusk warband"
+    - "the Stone-Bone tribe"
+  victim:
+    - "a foolish merchant"
+    - "a spy in elder-cloth"
+    - "a careless scout"
+  place:
+    - "the river crossing"
+    - "the broken bridge"
+    - "the burned hall"
+    - "the stoneberg pass"

--- a/content/npcs/archetypes/village_elder.yaml
+++ b/content/npcs/archetypes/village_elder.yaml
@@ -45,3 +45,34 @@ backstory_hooks:
   - "Served ${predecessor} as reeve before the old one passed"
   - "Brokered peace with ${neighbouring_settlement} after ${past_conflict}"
   - "Lost ${relation} to ${past_disaster}"
+
+# Substitution pools for the ${slot} placeholders above. See orc_raider.yaml for
+# the contract — every slot referenced in backstory_hooks (other than the
+# engine-reserved ${years_ago}) must appear here.
+slot_pools:
+  predecessor:
+    - "Old Halfast"
+    - "Mira-the-Steady"
+    - "Reeve Branvik"
+    - "Goodwife Thane"
+  neighbouring_settlement:
+    - "Westfen"
+    - "Stoneford"
+    - "Hollow Hill"
+    - "Pine-Reach"
+  past_conflict:
+    - "the cattle quarrel"
+    - "the salt-tax dispute"
+    - "the boundary trial"
+    - "the year of the broken weir"
+  relation:
+    - "a son"
+    - "a daughter"
+    - "an apprentice"
+    - "a younger brother"
+    - "an older sister"
+  past_disaster:
+    - "the long winter"
+    - "the river fever"
+    - "a wolf-attack"
+    - "the fire that took half the granary"

--- a/src/content.rs
+++ b/src/content.rs
@@ -506,7 +506,7 @@ impl Content {
         // npc.generate's substitute_slots leaves unknown slots verbatim — leaking raw
         // template strings like "${enemy_archetype}" into history events that the DM
         // agent then has no way to render naturally.
-        const RESERVED_SLOTS: &[&str] = &["years_ago"];
+        const RESERVED_SLOTS: &[&str] = &[RESERVED_SLOT_YEARS_AGO];
         for (arch_id, arch) in &self.archetypes {
             for hook in &arch.backstory_hooks {
                 for slot in extract_slots(hook) {
@@ -618,32 +618,41 @@ impl Content {
     }
 }
 
+/// Reserved slot name: the engine substitutes `${years_ago}` with a random integer
+/// 1..=50 at npc.generate time and skips it during validation. Defined here as the
+/// single source of truth so npcs::substitute_slots and content::validate can never
+/// drift on what counts as engine-reserved.
+pub(crate) const RESERVED_SLOT_YEARS_AGO: &str = "years_ago";
+
+/// Find the next `${slot}` placeholder in `template`, starting at byte offset `from`.
+/// Returns the byte range of the entire `${slot}` literal (inclusive of the leading
+/// `$` and the trailing `}`) and the slot name. `None` if no fully-closed `${slot}`
+/// remains; an unterminated `${...` tail is treated as no match (callers preserve or
+/// drop the tail however they like — the scanner itself doesn't care).
+///
+/// Both `content::extract_slots` (validation) and `npcs::substitute_slots` use this
+/// primitive, so any future change to placeholder syntax lands in one place.
+pub(crate) fn next_slot(template: &str, from: usize) -> Option<(std::ops::Range<usize>, &str)> {
+    let rest = template.get(from..)?;
+    let dollar = rest.find("${")?;
+    let name_start_in_rest = dollar + 2;
+    let after_open = rest.get(name_start_in_rest..)?;
+    let close = after_open.find('}')?;
+    let name = &after_open[..close];
+    let abs_start = from + dollar;
+    let abs_end = from + name_start_in_rest + close + 1; // include the `}`
+    Some((abs_start..abs_end, name))
+}
+
 /// Pull every `${slot}` placeholder name out of a template string. Used by validation
-/// (cross-checking that backstory_hook slots have matching slot_pools entries) and
-/// kept here next to the validate impl so both stay aligned. Tolerates malformed
-/// `${...` (no closing brace) by ignoring the unterminated tail.
+/// (cross-checking that backstory_hook slots have matching slot_pools entries).
+/// Tolerates malformed `${...` (no closing brace) by ignoring the unterminated tail.
 fn extract_slots(template: &str) -> Vec<String> {
     let mut out = Vec::new();
-    let mut chars = template.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '$' || chars.peek() != Some(&'{') {
-            continue;
-        }
-        chars.next(); // consume '{'
-        let mut slot = String::new();
-        let mut closed = false;
-        while let Some(&nc) = chars.peek() {
-            if nc == '}' {
-                chars.next();
-                closed = true;
-                break;
-            }
-            slot.push(nc);
-            chars.next();
-        }
-        if closed {
-            out.push(slot);
-        }
+    let mut from = 0;
+    while let Some((range, name)) = next_slot(template, from) {
+        out.push(name.to_string());
+        from = range.end;
     }
     out
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -159,6 +159,14 @@ pub struct Archetype {
     pub hostile_triggers: Vec<String>,
     #[serde(default)]
     pub peace_hooks: Vec<String>,
+    /// Per-archetype substitution table for `${slot}` placeholders in `backstory_hooks`.
+    /// At generation time, each `${name}` in a chosen hook is replaced with one randomly
+    /// picked entry from `slot_pools[name]`. The reserved slot `${years_ago}` is auto-
+    /// filled with a random integer 1..=50 by the engine and does not need a pool.
+    /// Slots without a pool are left as `${slot}` so the DM agent (or a future
+    /// reconciliation pass) can bind them to concrete entities.
+    #[serde(default)]
+    pub slot_pools: BTreeMap<String, Vec<String>>,
     /// Catch-all for forward-compat / agent-readable fields not yet mechanised.
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, serde_yaml_ng::Value>,
@@ -493,6 +501,30 @@ impl Content {
             }
         }
 
+        // Every ${slot} placeholder in a backstory_hook must have a matching entry in
+        // slot_pools (or be the engine-reserved ${years_ago}). Without this check,
+        // npc.generate's substitute_slots leaves unknown slots verbatim — leaking raw
+        // template strings like "${enemy_archetype}" into history events that the DM
+        // agent then has no way to render naturally.
+        const RESERVED_SLOTS: &[&str] = &["years_ago"];
+        for (arch_id, arch) in &self.archetypes {
+            for hook in &arch.backstory_hooks {
+                for slot in extract_slots(hook) {
+                    if RESERVED_SLOTS.contains(&slot.as_str()) {
+                        continue;
+                    }
+                    let pool_present = arch.slot_pools.get(&slot).is_some_and(|v| !v.is_empty());
+                    if !pool_present {
+                        anyhow::bail!(
+                            "archetype {arch_id:?} backstory hook references slot \
+                             ${{{slot}}} but slot_pools.{slot} is missing or empty; \
+                             add a pool entry or remove the slot from the hook"
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -584,6 +616,36 @@ impl Content {
             _ => false,
         }
     }
+}
+
+/// Pull every `${slot}` placeholder name out of a template string. Used by validation
+/// (cross-checking that backstory_hook slots have matching slot_pools entries) and
+/// kept here next to the validate impl so both stay aligned. Tolerates malformed
+/// `${...` (no closing brace) by ignoring the unterminated tail.
+fn extract_slots(template: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' || chars.peek() != Some(&'{') {
+            continue;
+        }
+        chars.next(); // consume '{'
+        let mut slot = String::new();
+        let mut closed = false;
+        while let Some(&nc) = chars.peek() {
+            if nc == '}' {
+                chars.next();
+                closed = true;
+                break;
+            }
+            slot.push(nc);
+            chars.next();
+        }
+        if closed {
+            out.push(slot);
+        }
+    }
+    out
 }
 
 fn parse_roll_modifier(v: &serde_yaml_ng::Value) -> Option<RollModifier> {
@@ -820,6 +882,7 @@ mod tests {
                         backstory_hooks: vec![],
                         hostile_triggers: vec![],
                         peace_hooks: vec![],
+                        slot_pools: BTreeMap::new(),
                         extra: BTreeMap::new(),
                     },
                 );
@@ -843,6 +906,81 @@ mod tests {
             msg.contains("phantom_sword") && msg.contains("unknown item base"),
             "error should name the offending base and what's wrong: {msg}"
         );
+    }
+
+    #[test]
+    fn validate_rejects_archetype_with_uncovered_backstory_slot() {
+        // Regression for issue #19: a backstory_hook referencing a ${slot} with no
+        // matching slot_pools entry used to leak the raw placeholder into history
+        // events. Validation now refuses to load such an archetype at startup.
+        let mut bad_archetypes = BTreeMap::new();
+        bad_archetypes.insert(
+            "leaky".into(),
+            Archetype {
+                id: "leaky".into(),
+                species: "human".into(),
+                role_hint: "neutral".into(),
+                typical_age_years: None,
+                stats: BTreeMap::new(),
+                hp_formula: None,
+                ac_base: None,
+                speed_ft: None,
+                proficiencies: vec![],
+                loadout: vec![],
+                plan_pool: vec![],
+                ideology_pool: vec![],
+                backstory_hooks: vec!["Was once ${some_role} in ${some_place}".into()],
+                hostile_triggers: vec![],
+                peace_hooks: vec![],
+                // Pool only covers some_role; some_place is missing.
+                slot_pools: {
+                    let mut m = BTreeMap::new();
+                    m.insert("some_role".into(), vec!["a tax-collector".into()]);
+                    m
+                },
+                extra: BTreeMap::new(),
+            },
+        );
+        let content = Content {
+            abilities: vec![],
+            skills: vec![],
+            damage_types: vec![],
+            conditions: BTreeMap::new(),
+            biomes: BTreeMap::new(),
+            weapons: BTreeMap::new(),
+            enchantments: BTreeMap::new(),
+            archetypes: bad_archetypes,
+            name_pools: BTreeMap::new(),
+            setup_questions: vec![],
+            death_events: vec![],
+            item_bases: BTreeMap::new(),
+            encumbrance: EncumbranceRules {
+                capacity_per_str: 15,
+                encumbered_threshold_pct: 67,
+                overloaded_threshold_pct: 100,
+            },
+        };
+        let err = content
+            .validate()
+            .expect_err("should reject archetype with uncovered backstory slot");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("some_place") && msg.contains("slot_pools"),
+            "error should name the offending slot and what's missing: {msg}"
+        );
+    }
+
+    #[test]
+    fn extract_slots_pulls_names_and_skips_unterminated() {
+        // Standalone unit test for the helper used by validate. Single ${a} → ["a"].
+        // Multiple ${a} ${b} → ["a", "b"]. Unterminated `${trailing` is skipped.
+        assert_eq!(extract_slots("hello ${name}"), vec!["name".to_string()]);
+        assert_eq!(
+            extract_slots("${a} and ${b}"),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert!(extract_slots("no slots here").is_empty());
+        assert!(extract_slots("${unterminated").is_empty());
     }
 
     #[test]

--- a/src/npcs.rs
+++ b/src/npcs.rs
@@ -533,55 +533,43 @@ fn pick_many<R: Rng + ?Sized>(rng: &mut R, pool: &[String], n: usize) -> Vec<Str
 
 /// Substitute `${slot}` placeholders in a backstory hook template.
 ///
-/// - `${years_ago}` — reserved, replaced with a random integer 1..=50.
-/// - Any other `${name}` — looked up in `slot_pools[name]`; if present, replaced with
-///   one randomly picked entry. Missing pool means the slot is left verbatim so a
-///   later reconciliation pass (or the DM agent) can bind it.
+/// - `${years_ago}` (reserved, see [`crate::content::RESERVED_SLOT_YEARS_AGO`]) is
+///   replaced with a random integer 1..=50.
+/// - Any other `${name}` is looked up in `slot_pools[name]`; if present and non-empty,
+///   replaced with one randomly picked entry. Missing pool means the slot is left
+///   verbatim so a later reconciliation pass (or the DM agent) can bind it.
 ///
-/// `Content::validate` enforces that every slot referenced in `backstory_hooks` (other
-/// than `years_ago`) has a pool entry, so in normal use the verbatim fallback only
-/// fires for forward-compat slots an author hasn't pooled yet.
+/// Uses [`crate::content::next_slot`] as the shared scanner — `${...}` syntax stays
+/// in lockstep with the validation pass that enforces pool coverage at load time.
+/// An unterminated `${...` tail is preserved verbatim by the implicit tail copy at
+/// the end (`next_slot` returns `None`, the remaining bytes flow through unchanged).
+///
+/// `Content::validate` enforces that every slot referenced in `backstory_hooks`
+/// (other than `${years_ago}`) has a pool entry, so in normal use the verbatim
+/// fallback only fires for forward-compat slots an author hasn't pooled yet.
 fn substitute_slots<R: Rng + ?Sized>(
     template: &str,
     slot_pools: &std::collections::BTreeMap<String, Vec<String>>,
     rng: &mut R,
 ) -> String {
     let mut out = String::with_capacity(template.len());
-    let mut chars = template.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '$' || chars.peek() != Some(&'{') {
-            out.push(c);
-            continue;
-        }
-        chars.next(); // consume '{'
-        let mut slot = String::new();
-        let mut closed = false;
-        while let Some(&nc) = chars.peek() {
-            if nc == '}' {
-                chars.next();
-                closed = true;
-                break;
-            }
-            slot.push(nc);
-            chars.next();
-        }
-        if !closed {
-            // Unterminated `${...` — emit the literal we consumed and stop scanning.
-            out.push_str("${");
-            out.push_str(&slot);
-            continue;
-        }
-        if slot == "years_ago" {
+    let mut from = 0;
+    while let Some((range, name)) = crate::content::next_slot(template, from) {
+        out.push_str(&template[from..range.start]);
+        if name == crate::content::RESERVED_SLOT_YEARS_AGO {
             let years = rng.random_range(1..=50i32);
             out.push_str(&years.to_string());
-        } else if let Some(pool) = slot_pools.get(&slot).filter(|v| !v.is_empty()) {
+        } else if let Some(pool) = slot_pools.get(name).filter(|v| !v.is_empty()) {
             out.push_str(&pool[rng.random_range(0..pool.len())]);
         } else {
-            out.push_str("${");
-            out.push_str(&slot);
-            out.push('}');
+            // No pool for this slot — emit verbatim so the DM agent (or a later
+            // reconciliation pass) can bind it. Validation prevents this from
+            // happening today for any declared backstory_hook.
+            out.push_str(&template[range.clone()]);
         }
+        from = range.end;
     }
+    out.push_str(&template[from..]);
     out
 }
 

--- a/src/npcs.rs
+++ b/src/npcs.rs
@@ -206,12 +206,13 @@ pub fn generate(
         })
         .collect();
 
-    // Prepare reconciliation substitutions: for slots we can satisfy without touching the
-    // DB, do them here. Everything else stays as ${slot} so the DM agent sees the raw
-    // placeholder.
+    // Substitute every ${slot} the archetype can satisfy from its slot_pools (and the
+    // engine-reserved ${years_ago}). Slots without a pool entry stay raw for the DM
+    // agent — Content::validate enforces full coverage of declared backstory_hooks at
+    // load time, so this is only relevant for forward-compat slots.
     let hook_texts: Vec<String> = chosen_hooks
         .iter()
-        .map(|h| minimal_slot_substitute(h, &mut rng))
+        .map(|h| substitute_slots(h, &arch.slot_pools, &mut rng))
         .collect();
 
     let species_label = arch.species.clone();
@@ -530,11 +531,58 @@ fn pick_many<R: Rng + ?Sized>(rng: &mut R, pool: &[String], n: usize) -> Vec<Str
     shuffled.into_iter().take(n).collect()
 }
 
-/// Replace `${years_ago}` with a concrete integer; leave every other `${slot}` verbatim
-/// so a later reconciliation pass (or the DM agent) can bind it to concrete entities.
-fn minimal_slot_substitute<R: Rng + ?Sized>(template: &str, rng: &mut R) -> String {
-    let years = rng.random_range(1..=50i32);
-    template.replace("${years_ago}", &years.to_string())
+/// Substitute `${slot}` placeholders in a backstory hook template.
+///
+/// - `${years_ago}` — reserved, replaced with a random integer 1..=50.
+/// - Any other `${name}` — looked up in `slot_pools[name]`; if present, replaced with
+///   one randomly picked entry. Missing pool means the slot is left verbatim so a
+///   later reconciliation pass (or the DM agent) can bind it.
+///
+/// `Content::validate` enforces that every slot referenced in `backstory_hooks` (other
+/// than `years_ago`) has a pool entry, so in normal use the verbatim fallback only
+/// fires for forward-compat slots an author hasn't pooled yet.
+fn substitute_slots<R: Rng + ?Sized>(
+    template: &str,
+    slot_pools: &std::collections::BTreeMap<String, Vec<String>>,
+    rng: &mut R,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' || chars.peek() != Some(&'{') {
+            out.push(c);
+            continue;
+        }
+        chars.next(); // consume '{'
+        let mut slot = String::new();
+        let mut closed = false;
+        while let Some(&nc) = chars.peek() {
+            if nc == '}' {
+                chars.next();
+                closed = true;
+                break;
+            }
+            slot.push(nc);
+            chars.next();
+        }
+        if !closed {
+            // Unterminated `${...` — emit the literal we consumed and stop scanning.
+            out.push_str("${");
+            out.push_str(&slot);
+            continue;
+        }
+        if slot == "years_ago" {
+            let years = rng.random_range(1..=50i32);
+            out.push_str(&years.to_string());
+        } else if let Some(pool) = slot_pools.get(&slot).filter(|v| !v.is_empty()) {
+            out.push_str(&pool[rng.random_range(0..pool.len())]);
+        } else {
+            out.push_str("${");
+            out.push_str(&slot);
+            out.push('}');
+        }
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tests/npcs.rs
+++ b/tests/npcs.rs
@@ -306,6 +306,62 @@ async fn orc_raider_loadout_items_have_real_stats_not_zero() -> Result<()> {
 }
 
 #[tokio::test]
+async fn backstory_summaries_have_no_unresolved_placeholders() -> Result<()> {
+    // Regression for issue #19: orc_raider backstory summaries used to leak raw
+    // template strings like "Killed ${enemy_archetype} in single combat over ${cause}"
+    // into history events. After the fix, every ${slot} in a backstory_hook is bound
+    // to a value from the archetype's slot_pools (or to a random integer for the
+    // engine-reserved ${years_ago}); Content::validate refuses to load if any slot
+    // is uncovered.
+    let h = connect().await?;
+    let zone_id = setup_world(&h.client).await?;
+
+    // A few orcs to sample multiple hook draws — npc.generate picks 3-5 hooks per NPC.
+    let mut summaries: Vec<String> = Vec::new();
+    for _ in 0..5 {
+        let gen = call(
+            &h.client,
+            "npc.generate",
+            serde_json::json!({ "archetype": "orc_raider", "zone_id": zone_id }),
+        )
+        .await?;
+        let orc_id = gen["character_id"].as_i64().unwrap();
+        let recalled = call(
+            &h.client,
+            "character.recall",
+            serde_json::json!({
+                "character_id": orc_id,
+                "kind_prefix": "history.",
+                "since_hour": -1_000_000_i64
+            }),
+        )
+        .await?;
+        for ev in recalled["events"].as_array().unwrap() {
+            summaries.push(
+                ev["summary"]
+                    .as_str()
+                    .expect("summary should be a string")
+                    .to_string(),
+            );
+        }
+    }
+
+    assert!(
+        !summaries.is_empty(),
+        "5 orcs × 3-5 hooks each should produce ≥1 backstory event"
+    );
+    for s in &summaries {
+        assert!(
+            !s.contains("${"),
+            "backstory summary should have no unresolved ${{slot}} placeholders; got: {s:?}"
+        );
+    }
+
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn recall_filters_by_kind_prefix_and_since_hour() -> Result<()> {
     let h = connect().await?;
     setup_world(&h.client).await?;


### PR DESCRIPTION
Fixes #19.

## Symptom

Pre-fix, `npc.generate`'s `minimal_slot_substitute` only replaced `${years_ago}` and left every other `${slot}` raw. The orc_raider's hooks reference 9 other slots (settlement, oppressor, enemy_archetype, cause, etc.), so backstory event summaries surfaced strings like:

```
"Killed ${enemy_archetype} in single combat over ${cause}"
"Carries a trophy taken from ${victim} at ${place}"
"Was exiled from ${tribe} for breaking a sacred law"
```

Useless narration material for the DM agent and an immersion break if the agent surfaces them verbatim.

## Fix — three pieces

### Schema

`Archetype` gains `slot_pools: BTreeMap<String, Vec<String>>`. Per-archetype substitution pools live in YAML (content-is-data rule preserved).

### Content

`orc_raider.yaml` and `village_elder.yaml` gain `slot_pools` covering every placeholder their `backstory_hooks` use. Original prose, no SRD/WotC references — settlements like "Ashbrook" and "Stoneford", clan names like "Black-Pine clan" and "Red-Tusk warband", causes like "a stolen blade" and "a debt of blood".

### Code

- `npcs::substitute_slots` replaces `minimal_slot_substitute`. It scans the template for `${name}` occurrences, looks up `name` in the archetype's `slot_pools`, picks one entry at random. Reserved slot `${years_ago}` keeps the existing random-int handling. Slots without a pool stay raw (forward-compat path, unreachable today thanks to validation). Tolerates malformed `${...` (no closing brace) by skipping the tail.

- `Content::validate` refuses to load if any `backstory_hook` references a slot that isn't in `slot_pools` or the reserved set. Same shape as the loadout-base validation from PR #25 — fail closed at startup so a bad archetype crashes the server up-front rather than producing leaky summaries mid-game.

## Tests

- **`src/content.rs::validate_rejects_archetype_with_uncovered_backstory_slot`** — hand-built archetype whose `backstory_hooks` references `${some_place}` but whose `slot_pools` only covers `some_role`. Asserts `Content::validate` errors with both the offending slot name and "slot_pools".
- **`src/content.rs::extract_slots_pulls_names_and_skips_unterminated`** — standalone unit test for the helper that backs the validator. Single, multiple, no-slot, and unterminated-tail cases.
- **`tests/npcs.rs::backstory_summaries_have_no_unresolved_placeholders`** — generates 5 orc_raiders (3-5 hooks each, so ≥15 summaries collected), recalls each NPC's `history.*` events, asserts no summary contains a literal `${`. Pre-fix this would catch every orc_raider's backstory.

## Test plan

- [x] `cargo test --tests` — 13 binaries pass; 108 unit + 4 npc tests (was 106 / 3 before this PR)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Without the validation, current orc_raider/village_elder content keeps generating fine. With validation, both archetypes load only because they now provide slot_pools — confirms both halves of this PR ship together.

## IP rule check

Per CLAUDE.md "no WotC trademarks or non-SRD copyrighted text" — every entry in the new slot_pools is original prose. Place names like "Ashbrook" / "Stoneford" / "Pine-Reach" are generic fantasy compounds; faction names like "Black-Pine clan" / "Red-Tusk warband" are made up; phrases like "a debt of blood" and "the salt-treaty" are open-domain narrative tropes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed NPC backstory generation to properly resolve all placeholder tokens with varied content from available options.

* **Tests**
  * Added regression test for backstory placeholder resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->