### PR TITLE
checks: itemise ability-targeting effects in resolve_check breakdown (fixes #17)

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -181,7 +181,23 @@ fn resolve_ability(
     }
 }
 
-fn effective_ability_score(conn: &Connection, character_id: i64, ability: &str) -> Result<i32> {
+/// Per-effect contribution to a composed ability score. Surfaces the `source` so the
+/// breakdown can attribute the change rather than just showing the post-composition
+/// effective score in the `ability:<x>` line.
+#[derive(Debug, Clone)]
+struct AbilityEffectContribution {
+    source: String,
+    modifier: i32,
+}
+
+/// Compose an ability score: base from the character row + every active effect targeting
+/// that ability column. Returns the composed score and the list of contributing effects
+/// (so the caller can itemise them on the breakdown — see issue #17).
+fn effective_ability_score(
+    conn: &Connection,
+    character_id: i64,
+    ability: &str,
+) -> Result<(i32, Vec<AbilityEffectContribution>)> {
     let col = match ability {
         "str" => "str_score",
         "dex" => "dex_score",
@@ -198,15 +214,21 @@ fn effective_ability_score(conn: &Connection, character_id: i64, ability: &str) 
             |row| row.get(0),
         )
         .with_context(|| format!("read {col} for character {character_id}"))?;
-    let modifier_sum: i32 = conn
-        .query_row(
-            "SELECT COALESCE(SUM(modifier), 0) FROM effects
-             WHERE target_character_id = ?1 AND active = 1 AND target_key = ?2",
-            rusqlite::params![character_id, col],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
-    Ok(base + modifier_sum)
+
+    let mut stmt = conn.prepare(
+        "SELECT source, modifier FROM effects
+         WHERE target_character_id = ?1 AND active = 1 AND target_key = ?2",
+    )?;
+    let contributions: Vec<AbilityEffectContribution> = stmt
+        .query_map(rusqlite::params![character_id, col], |row| {
+            Ok(AbilityEffectContribution {
+                source: row.get(0)?,
+                modifier: row.get(1)?,
+            })
+        })?
+        .collect::<rusqlite::Result<_>>()?;
+    let modifier_sum: i32 = contributions.iter().map(|c| c.modifier).sum();
+    Ok((base + modifier_sum, contributions))
 }
 
 fn ability_modifier(score: i32) -> i32 {
@@ -290,7 +312,8 @@ pub fn resolve(
     let kind = parse_kind(&p.kind)?;
 
     let ability = resolve_ability(content, kind, &p.target_key, p.ability.as_deref())?;
-    let effective_score = effective_ability_score(conn, p.character_id, &ability)?;
+    let (effective_score, ability_effect_contribs) =
+        effective_ability_score(conn, p.character_id, &ability)?;
     let ability_mod = ability_modifier(effective_score);
 
     // Proficiency row lookup. For skill_check/save/attack_roll we consult the
@@ -427,6 +450,27 @@ pub fn resolve(
             )),
         },
     ];
+
+    // Itemise every active effect that contributed to the composed ability score
+    // (issue #17). Distinct kind prefix `effect:ability:` so a consumer can tell these
+    // annotation entries apart from `effect:<source>` entries (which contribute to the
+    // total via effect_flat_sum). The ability:<x> line above already accounts for the
+    // composed mod — these per-effect lines exist purely to attribute the source.
+    for c in &ability_effect_contribs {
+        if c.modifier != 0 {
+            breakdown.push(BreakdownEntry {
+                kind: format!("effect:ability:{}", c.source),
+                value: c.modifier,
+                reason: Some(format!(
+                    "{source} → {modifier:+} {ability_up} (folded into effective score above)",
+                    source = c.source,
+                    modifier = c.modifier,
+                    ability_up = ability.to_ascii_uppercase(),
+                )),
+            });
+        }
+    }
+
     if prof_contrib != 0 || ranks != 0 || prof.is_some() {
         breakdown.push(BreakdownEntry {
             kind: "proficiency".into(),

--- a/tests/checks.rs
+++ b/tests/checks.rs
@@ -273,6 +273,80 @@ async fn ideology_alignment_modifier_threads_through_event_payload() -> Result<(
     Ok(())
 }
 
+// ── Regression test for issue #17 (effect source attribution in breakdown) ──
+
+#[tokio::test]
+async fn ability_targeting_effects_appear_in_resolve_check_breakdown() -> Result<()> {
+    // Pre-fix, an ability-targeting effect (e.g. potion:giant-strength → +2 str_score)
+    // got silently composed into the `effective_str` value behind the ability:str
+    // breakdown line. The DM agent could see the score had jumped from 12 → 14 but
+    // not WHY — no `effect:<source>` entry made it into the response. After the fix,
+    // every ability-targeting effect with non-zero modifier emits its own
+    // `effect:ability:<source>` line so the agent can attribute the change.
+    let h = connect().await?;
+    let cid = make_character(&h.client, "Brennan").await?;
+    // make_character builds a STR 14 ranger; bump to a known starting point of 12 by
+    // re-creating instead. Simpler: just use the existing 14 and apply +2 → effective 16.
+    call(
+        &h.client,
+        "apply_effect",
+        serde_json::json!({
+            "target_character_id": cid,
+            "source": "potion:giant-strength",
+            "target_kind": "ability",
+            "target_key": "str_score",
+            "modifier": 2
+        }),
+    )
+    .await?;
+
+    let result = call(
+        &h.client,
+        "resolve_check",
+        serde_json::json!({
+            "character_id": cid,
+            "kind": "ability_check",
+            "target_key": "str"
+        }),
+    )
+    .await?;
+
+    let breakdown = result["breakdown"].as_array().context("breakdown")?;
+
+    // The existing ability:str line should still be present and report the composed
+    // effective score (14 base + 2 from potion = 16).
+    let ability_line = breakdown
+        .iter()
+        .find(|b| b["kind"] == "ability:str")
+        .context("breakdown should still include ability:str")?;
+    assert!(
+        ability_line["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("effective STR score 16"),
+        "ability line should report the composed score 16; got {ability_line:?}"
+    );
+
+    // The new effect attribution line.
+    let effect_line = breakdown
+        .iter()
+        .find(|b| b["kind"] == "effect:ability:potion:giant-strength")
+        .context("breakdown should now include effect:ability:potion:giant-strength")?;
+    assert_eq!(
+        effect_line["value"].as_i64(),
+        Some(2),
+        "effect line value should be the raw modifier; got {effect_line:?}"
+    );
+    let reason = effect_line["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("potion:giant-strength") && reason.contains("STR"),
+        "effect line reason should name the source and the ability; got {effect_line:?}"
+    );
+
+    h.client.cancel().await?;
+    Ok(())
+}
+
 // ── Sanity: tools listed ──────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #17.

## Symptom

Pre-fix, an ability-targeting effect (e.g. `potion:giant-strength` → +2 `str_score`) got silently composed into the value behind the `ability:str` breakdown line. The DM agent could see `effective_str` had jumped from 14 → 16 but had no source attribution — the only audit trail lived on `character.get`'s `active_effects` array, requiring an extra round-trip per check to know **why** a stat was what it was.

Check-key effects (e.g. Bless on persuasion) were already itemised as `effect:<source>` entries; ability effects were the asymmetric hole.

## Concrete before/after

**Before** — STR check with potion:giant-strength active (+2 to str_score):
```jsonc
{
  "breakdown": [
    {"kind": "d20:normal", "value": 16, "reason": "rolled [16]"},
    {"kind": "ability:str", "value": 3, "reason": "mod from effective STR score 16"}
    // <- the +2 source is invisible
  ]
}
```

**After**:
```jsonc
{
  "breakdown": [
    {"kind": "d20:normal", "value": 16, "reason": "rolled [16]"},
    {"kind": "ability:str", "value": 3, "reason": "mod from effective STR score 16"},
    {
      "kind": "effect:ability:potion:giant-strength",
      "value": 2,
      "reason": "potion:giant-strength → +2 STR (folded into effective score above)"
    }
  ]
}
```

## Fix

Two changes in `src/checks.rs`:

- **`effective_ability_score`** now returns `(score, Vec<AbilityEffectContribution>)` rather than just the composed score, surfacing each contributing effect's source + modifier alongside the sum.

- **The breakdown construction** adds one `effect:ability:<source>` entry per ability-targeting effect with non-zero modifier, after the existing `ability:<x>` line.

### Distinct `effect:ability:<source>` prefix (vs `effect:<source>`)

Two effect families now appear in the breakdown:

| Kind | Contributes to total? | Where |
|---|---|---|
| `effect:<source>` | yes (via `effect_flat_sum`) | check-key effects (Bless on persuasion) |
| `effect:ability:<source>` | no — already inside `ability:<x>` | ability-targeting effects (potion +STR) |

Distinct prefixes let an LLM consumer tell annotation entries apart from roll contributors without summing the value column. Reason field on the new lines explicitly says "folded into effective score above" to head off any double-counting confusion.

## Regression test

`tests/checks.rs::ability_targeting_effects_appear_in_resolve_check_breakdown`:

1. Make a character (STR 14)
2. `apply_effect` → +2 to `str_score` from `potion:giant-strength`
3. `resolve_check` → `ability_check` on `str`
4. Assert:
   - `ability:str` line is still present and reports the composed score (16)
   - `effect:ability:potion:giant-strength` line is now in the breakdown with `value: 2` and a reason naming both the source and the ability

Pre-fix this would have failed at step 4's second assertion (no `effect:ability:*` lines existed).

## Test plan

- [x] `cargo test --tests` — all 13 binaries pass; the new test passes; existing `bless_contributes_a_rolled_die_to_persuasion` and other check breakdown tests still pass (they don't use ability effects, so the new code path doesn't affect them)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)