### PR TITLE
config: validate DMMCP_LOG_LEVEL up front (fixes #35)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ impl Config {
                 bind: env_or("DMMCP_HTTP_BIND", IpAddr::from([0, 0, 0, 0]), parse_str)?,
                 port: env_or("DMMCP_HTTP_PORT", 3000_u16, parse_str)?,
             },
-            log_level: env_or("DMMCP_LOG_LEVEL", "info".to_string(), |v| Ok(v.to_string()))?,
+            log_level: env_or("DMMCP_LOG_LEVEL", "info".to_string(), parse_log_level)?,
             content_dir: match env::var("DMMCP_CONTENT_DIR") {
                 Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
                 _ => None,
@@ -93,6 +93,31 @@ where
 {
     v.parse::<T>()
         .map_err(|e| anyhow::anyhow!("parse error: {e}"))
+}
+
+/// Validate a tracing filter directive (e.g. `info`, `debug`, `dm_mcp=trace,warn`).
+///
+/// `EnvFilter::try_new` alone is too permissive — it accepts a typoed level like
+/// `warng` as if it were a target name with no level (silently degrading to the
+/// default). To catch the common operator-typo case we additionally enforce:
+/// any single bare word (no `=` or `,`) must be one of the documented level names.
+/// More structured directives still go through `EnvFilter::try_new` for full syntax
+/// validation.
+fn parse_log_level(v: &str) -> Result<String> {
+    const LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error", "off"];
+    let trimmed = v.trim();
+    if !trimmed.contains('=') && !trimmed.contains(',') {
+        if !LEVELS.contains(&trimmed.to_ascii_lowercase().as_str()) {
+            anyhow::bail!(
+                "unknown level {trimmed:?}; expected one of {LEVELS:?} or a per-target \
+                 directive like `dm_mcp=debug,warn`"
+            );
+        }
+        return Ok(trimmed.to_ascii_lowercase());
+    }
+    tracing_subscriber::EnvFilter::try_new(trimmed)
+        .map_err(|e| anyhow::anyhow!("invalid tracing filter directive: {e}"))?;
+    Ok(trimmed.to_string())
 }
 
 /// Accept any documented SQLite `journal_mode` value. Normalise to uppercase so the PRAGMA
@@ -255,6 +280,44 @@ mod tests {
             );
             assert!(
                 msg.contains("loose"),
+                "error should include the offending value: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn log_level_accepts_simple_directive() {
+        with_clean_env(|| {
+            // SAFETY: env_lock is held.
+            unsafe { env::set_var("DMMCP_LOG_LEVEL", "warn") };
+            let cfg = Config::from_env().expect("simple directive should parse");
+            assert_eq!(cfg.log_level, "warn");
+        });
+    }
+
+    #[test]
+    fn log_level_accepts_per_target_directive() {
+        with_clean_env(|| {
+            // SAFETY: env_lock is held.
+            unsafe { env::set_var("DMMCP_LOG_LEVEL", "dm_mcp=trace,warn") };
+            let cfg = Config::from_env().expect("per-target directive should parse");
+            assert_eq!(cfg.log_level, "dm_mcp=trace,warn");
+        });
+    }
+
+    #[test]
+    fn log_level_rejects_garbage() {
+        with_clean_env(|| {
+            // SAFETY: env_lock is held.
+            unsafe { env::set_var("DMMCP_LOG_LEVEL", "warng") };
+            let err = Config::from_env().expect_err("should fail on misspelled level");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("DMMCP_LOG_LEVEL"),
+                "error should name the offending var: {msg}"
+            );
+            assert!(
+                msg.contains("warng"),
                 "error should include the offending value: {msg}"
             );
         });


### PR DESCRIPTION
Fixes #35.

## Symptom

`Config::from_env` (`src/config.rs:74`) read `DMMCP_LOG_LEVEL` and stuffed it into `log_level` with zero validation. A typo like `warng` didn't error at startup; whatever \`EnvFilter::new\` did with the bad string downstream was undefined from the operator's perspective.

## Why \`EnvFilter::try_new\` alone isn't enough

The naive fix \"run \`EnvFilter::try_new(v)\` and bail on error\" doesn't work — \`EnvFilter\` parses unknown bare words as **target names** with no level, silently degrading. \`try_new(\"warng\")\` returns Ok. Verified by unit test.

## Fix

\`parse_log_level\` now:
- For a single bare word (no \`=\` or \`,\`): require it be one of \`{trace, debug, info, warn, error, off}\`. Normalise to lowercase. Bail with a clear message naming the bad value otherwise.
- For structured directives (e.g. \`dm_mcp=trace,warn\`): still go through \`EnvFilter::try_new\` for full syntax validation.

Symmetric with \`parse_journal_mode\` and \`parse_synchronous\` which already bail on garbage.

## Tests

Three new unit tests in \`src/config.rs\`:
- \`log_level_accepts_simple_directive\`: \`warn\` → ok
- \`log_level_accepts_per_target_directive\`: \`dm_mcp=trace,warn\` → ok
- \`log_level_rejects_garbage\`: \`warng\` → bail with var name + value in message

## Test plan

- [x] \`cargo test --bin dm-mcp config::\` — all 10 config tests pass
- [x] \`cargo clippy --bin dm-mcp -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log level configuration now implements strict validation to enforce only supported level values, with improved error messages that clearly identify invalid inputs and the problematic configuration value.

* **Tests**
  * Added comprehensive unit tests covering log level validation scenarios, including acceptance of standard levels and per-target configurations, as well as proper error reporting for unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->