### PR TITLE
ci: pin third-party actions by SHA + tighten workflow permissions (fixes #36)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,12 @@ env:
   RUST_BACKTRACE: 1
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Default to read-only — every job in this file is read-only relative to the repo
+# (fmt, clippy, test, no-openssl). Without this block, push events would inherit
+# the repo default (often `contents: write`).
+permissions:
+  contents: read
+
 jobs:
   # ── 1. Format ──────────────────────────────────────────────────────────────
   fmt:
@@ -23,9 +29,9 @@ jobs:
     runs-on: arc-runner-dm-mcp
     steps:
       # rustfmt is a pure Rust binary — no C toolchain needed.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt
 
@@ -45,13 +51,13 @@ jobs:
             sleep 10
           done
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1  # v2.8.1
 
       - name: cargo clippy — deny all warnings
         run: cargo clippy --all-targets -- -D warnings
@@ -74,11 +80,11 @@ jobs:
             sleep 10
           done
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1  # v2.8.1
 
       - name: cargo build (release — verifies the release profile compiles clean)
         run: cargo build --release
@@ -103,11 +109,11 @@ jobs:
             sleep 10
           done
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1  # v2.8.1
 
       - name: Verify openssl is not in the dependency tree
         run: |

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -37,15 +37,15 @@ jobs:
             sleep 10
           done
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       # Cache the registry AND ~/.cargo/bin so cargo-audit doesn't recompile every run.
       # On self-hosted runners a cold cargo-audit build is ~30 minutes; this cuts that to
       # a restore + lockfile diff on warm cache hits.
       - name: Cache cargo registry + installed binaries
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0  # v5.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Default to read-only at the workflow level. Each job below explicitly elevates
+# only the scopes it actually needs (least-privilege per the GitHub hardening
+# guide). Previously all jobs inherited contents: write + packages: write +
+# id-token: write whether they used them or not.
 permissions:
-  contents: write
-  packages: write
-  # Required by docker/build-push-action's provenance/SBOM attestations, which
-  # request an OIDC token to sign the attestation manifest.
-  id-token: write
+  contents: read
 
 # Serialise release runs on the same ref so rapid main commits don't race each
 # other computing / pushing tags. `cancel-in-progress: false` lets an in-flight
@@ -31,19 +31,21 @@ jobs:
   compute-tag:
     name: Compute Next Version Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # only reads the git history to compute the next semver tag
     outputs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
       changelog: ${{ steps.tag.outputs.changelog }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute next tag (dry run — tag pushed after image build)
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@d28fa2ccfbd16e871a4bdf35e11b3ad1bd56c0c1  # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
@@ -56,6 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: compute-tag
     if: needs.compute-tag.outputs.new_tag
+    permissions:
+      contents: write   # `git push origin <tag>` after image upload succeeds
+      packages: write   # ghcr push
+      id-token: write   # SLSA provenance + SBOM attestation OIDC token
     steps:
       - name: Maximize Build Space
         run: |
@@ -66,17 +72,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       # docker/metadata-action@v6 and docker/build-push-action@v7 are JS
       # actions on the Node.js 24 runtime — require GitHub Actions runner
@@ -84,7 +90,7 @@ jobs:
       # should confirm before switching to them here.
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -97,7 +103,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Containerfile
@@ -136,9 +142,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compute-tag, build-and-push]
     if: needs.compute-tag.outputs.new_tag
+    permissions:
+      contents: write   # creates the GitHub Release row + uploads body
     steps:
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@aec2ec56f94eb8180ceec724245f64ef008b89f5  # v2.4.0
         with:
           tag_name: ${{ needs.compute-tag.outputs.new_tag }}
           name: Release ${{ needs.compute-tag.outputs.new_tag }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -29,13 +29,13 @@ jobs:
     runs-on: arc-runner-dm-mcp
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       # The action downloads its own trivy binary (no apt-get needed). Pinned
       # to a specific release — aquasecurity/trivy-action doesn't publish a
       # floating major-version tag, so we pin to v0.36.0 and bump explicitly.
       - name: Run Trivy filesystem secret scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: fs
           scanners: secret


### PR DESCRIPTION
Fixes #36.

## Summary

Two related hardening changes bundled because they touch the same set of workflow files:

### 1. SHA-pin every third-party action

Every \`uses:\` reference across the 4 workflows is now pinned to a 40-char SHA with a trailing \`# vX.Y.Z\` version comment so dependabot can keep them updated visibly.

| Action | Pinned SHA | Version comment |
|---|---|---|
| actions/checkout | \`1af3b93b...\` | v6.0.0 |
| actions/cache | \`a7833574...\` | v5.0.0 |
| dtolnay/rust-toolchain | \`29eef336...\` | stable (branch HEAD captured) |
| Swatinem/rust-cache | \`bc2d2e71...\` | v2.8.1 |
| docker/build-push-action | \`bcafcacb...\` | v7.1.0 |
| docker/login-action | \`5e57cd11...\` | v3.6.0 |
| docker/metadata-action | \`030e8812...\` | v6.0.0 |
| docker/setup-buildx-action | \`8d2750c6...\` | v3.12.0 |
| mathieudutour/github-tag-action | \`d28fa2cc...\` | v6.2 |
| softprops/action-gh-release | \`aec2ec56...\` | v2.4.0 |
| aquasecurity/trivy-action | \`a9c7b0f0...\` | v0.36.0 |

Tags are mutable. An upstream compromise (or someone moving the tag intentionally) injects code into our CI. SHA pinning is GitHub's [recommended practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

### 2. Tighten workflow permissions

- **release.yaml** — top-level was \`contents:write + packages:write + id-token:write\`. Now \`contents:read\` at the top, with each job elevating only what it needs:
  - \`compute-tag\` → \`contents:read\` (only reads git history)
  - \`build-and-push\` → \`contents:write\` (push tag), \`packages:write\` (ghcr), \`id-token:write\` (SLSA OIDC)
  - \`create-release\` → \`contents:write\` (Release row)
- **ci.yaml** — was missing top-level \`permissions:\` block entirely; would inherit repo defaults (often \`contents:write\`). Now explicitly \`contents:read\`, matching commit.yaml's already-correct shape.
- **commit.yaml** + **secret-scan.yaml** — permissions already correct, only the SHA pins changed.

## Test plan

- [x] After this PR's push, every workflow continues to run green
- [x] \`gh workflow view <name> --yaml\` shows SHA-pinned references
- [x] \`grep -E 'uses:.*@(v[0-9]+|stable)$' .github/workflows/*.yaml\` returns nothing (every action SHA-pinned)