### PR TITLE
cluster: input validation gaps in encounters/barter/conditions/events (fixes #41)

### DIFF
--- a/src/barter.rs
+++ b/src/barter.rs
@@ -334,8 +334,18 @@ fn emit_bargain_event_in_tx(
 }
 
 fn derive_dc(ratio: f64) -> i32 {
+    // Defensive: handle NaN and Infinity from upstream (e.g. requested_value == 0.0
+    // produces ratio = INF). NaN clamps via comparison-fail to FAIR_RATIO (DC base);
+    // Infinity clamps to a sane high ratio so the gap never goes negative-overflow.
+    // Without this, `(NaN * 100.0 / 10.0).ceil() as i32` is implementation-defined
+    // and `Infinity.ceil() as i32` saturates at i32::MAX.
+    let r = if ratio.is_nan() {
+        FAIR_RATIO
+    } else {
+        ratio.clamp(0.0, 2.0)
+    };
     // Ratio 0.9 → DC 10. Each 10% gap below 0.9 adds 2. Ratio 0.5 → DC 18.
-    let gap = (FAIR_RATIO - ratio).max(0.0);
+    let gap = (FAIR_RATIO - r).max(0.0);
     DC_BASE + ((gap * 100.0 / 10.0).ceil() as i32) * DC_PER_10PCT_GAP
 }
 
@@ -597,5 +607,32 @@ mod tests {
         .unwrap();
         assert_eq!(r.resolution, "refused");
         assert_eq!(r.outcome, "declined");
+    }
+
+    #[test]
+    fn derive_dc_handles_nan_and_infinity_gracefully() {
+        // NaN: clamps to FAIR_RATIO so the result is the base DC, not implementation-
+        // defined integer-from-NaN. (FAIR_RATIO is the no-gap point — DC equals BASE.)
+        let nan_dc = derive_dc(f64::NAN);
+        assert_eq!(nan_dc, DC_BASE, "NaN ratio should fall back to base DC");
+
+        // Infinity: would otherwise feed `(neg_gap * 100 / 10).ceil() as i32` which
+        // saturates at i32::MAX. The clamp to [0.0, 2.0] caps it at FAIR_RATIO+,
+        // so DC again equals BASE (gap = 0).
+        let inf_dc = derive_dc(f64::INFINITY);
+        assert_eq!(
+            inf_dc, DC_BASE,
+            "infinite ratio (free request) should fall back to base DC"
+        );
+
+        // Negative ratio (shouldn't happen but cheap to defend): clamps to 0.0,
+        // yielding the maximum-gap DC. Compute the expected via the same formula:
+        // gap = FAIR_RATIO - 0.0 = 0.9 → 9 chunks of 10% → DC = base + 9 * step.
+        let zero_dc = derive_dc(-1.0);
+        let expected = DC_BASE + (((FAIR_RATIO * 100.0 / 10.0).ceil() as i32) * DC_PER_10PCT_GAP);
+        assert_eq!(
+            zero_dc, expected,
+            "negative ratio should clamp to 0.0 producing max-gap DC"
+        );
     }
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -797,6 +797,7 @@ mod tests {
         let c = make_char(&mut conn, 14);
         conditions::apply(
             &mut conn,
+            &content,
             ApplyConditionParams {
                 character_id: c,
                 condition: "blinded".into(),
@@ -838,6 +839,7 @@ mod tests {
         // Apply blinded (self-disadvantage on attack_rolls) AND pass advantage via caller.
         conditions::apply(
             &mut conn,
+            &content,
             ApplyConditionParams {
                 character_id: c,
                 condition: "blinded".into(),

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -13,6 +13,7 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+use crate::content::Content;
 use crate::events::{self, EventSpec, Participant};
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -64,12 +65,29 @@ pub struct RemoveConditionResult {
 }
 
 /// Record a condition on a character and emit `condition.applied`.
-pub fn apply(conn: &mut Connection, p: ApplyConditionParams) -> Result<ApplyConditionResult> {
+pub fn apply(
+    conn: &mut Connection,
+    content: &Content,
+    p: ApplyConditionParams,
+) -> Result<ApplyConditionResult> {
     if p.condition.is_empty() {
         bail!("condition name must not be empty");
     }
     if p.severity < 1 {
         bail!("condition severity must be >= 1 (got {})", p.severity);
+    }
+    // Reject unknown condition names. Without this, a typo silently produces a row
+    // whose mechanical riders (disadvantage, auto-fail saves, etc.) never fire because
+    // resolve_check looks them up by name. The catalog is small (12 entries) so the
+    // diagnostic listing every valid name is bounded.
+    if !content.conditions.contains_key(p.condition.as_str()) {
+        let mut valid: Vec<&str> = content.conditions.keys().map(String::as_str).collect();
+        valid.sort();
+        bail!(
+            "unknown condition {:?}; valid conditions: {:?}",
+            p.condition,
+            valid
+        );
     }
 
     // Emit the event first so the source_event_id FK resolves once we write the row.
@@ -203,11 +221,11 @@ mod tests {
     use crate::characters::{self, CreateParams};
     use crate::db::schema;
 
-    fn fresh_conn() -> Connection {
+    fn fresh() -> (Connection, Content) {
         let mut conn = Connection::open_in_memory().unwrap();
         conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
         schema::migrate(&mut conn).unwrap();
-        conn
+        (conn, Content::load(None).unwrap())
     }
 
     fn make_char(conn: &mut Connection) -> i64 {
@@ -244,10 +262,11 @@ mod tests {
 
     #[test]
     fn apply_and_remove_round_trip() {
-        let mut conn = fresh_conn();
+        let (mut conn, content) = fresh();
         let c = make_char(&mut conn);
         let applied = apply(
             &mut conn,
+            &content,
             ApplyConditionParams {
                 character_id: c,
                 condition: "blinded".into(),
@@ -288,10 +307,11 @@ mod tests {
 
     #[test]
     fn double_remove_errors() {
-        let mut conn = fresh_conn();
+        let (mut conn, content) = fresh();
         let c = make_char(&mut conn);
         let applied = apply(
             &mut conn,
+            &content,
             ApplyConditionParams {
                 character_id: c,
                 condition: "poisoned".into(),
@@ -320,5 +340,39 @@ mod tests {
         )
         .expect_err("double remove should fail");
         assert!(format!("{err:#}").contains("already inactive"));
+    }
+
+    #[test]
+    fn apply_rejects_unknown_condition_name() {
+        // A typo like "paralised" used to silently insert a row whose mechanical
+        // riders never fire downstream. After the validate fix, the apply call
+        // bails up front and lists the valid set.
+        let (mut conn, content) = fresh();
+        let c = make_char(&mut conn);
+        let err = apply(
+            &mut conn,
+            &content,
+            ApplyConditionParams {
+                character_id: c,
+                condition: "paralised".into(), // misspelled "paralyzed"
+                severity: 1,
+                source_event_id: None,
+                expires_at_hour: None,
+                expires_after_rounds: None,
+                remove_on_save: None,
+            },
+        )
+        .expect_err("unknown condition name should bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("paralised") && msg.contains("unknown"),
+            "error should name the offender and the valid set: {msg}"
+        );
+        // Sanity: the message does include a real condition like "paralyzed" so
+        // a confused caller can spot the typo.
+        assert!(
+            msg.contains("paralyzed"),
+            "error should list a real condition for comparison: {msg}"
+        );
     }
 }

--- a/src/encounters.rs
+++ b/src/encounters.rs
@@ -101,6 +101,12 @@ pub const VALID_SIDES: &[&str] = &["player_side", "hostile", "neutral", "ally"];
 // ── Implementation ───────────────────────────────────────────────────────────
 
 pub fn create(conn: &mut Connection, p: CreateParams) -> Result<CreateResult> {
+    // XP budget is awarded to player_side participants on encounter.complete; allowing
+    // a negative value would let a malicious or buggy caller deduct XP from players,
+    // which has no game-rules basis. Reject up front rather than letting it propagate.
+    if p.xp_budget < 0 {
+        bail!("encounter xp_budget must be >= 0 (got {})", p.xp_budget);
+    }
     for part in &p.participants {
         if !VALID_SIDES.contains(&part.side.as_str()) {
             bail!(
@@ -637,5 +643,27 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r.xp_awarded_total, 100);
+    }
+
+    #[test]
+    fn create_rejects_negative_xp_budget() {
+        let mut conn = fresh();
+        let err = create(
+            &mut conn,
+            CreateParams {
+                zone_id: None,
+                name: None,
+                goal: "g".into(),
+                estimated_duration_hours: None,
+                xp_budget: -50,
+                participants: vec![],
+            },
+        )
+        .expect_err("negative xp_budget should bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("xp_budget") && msg.contains("-50"),
+            "error should name the field and value: {msg}"
+        );
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -57,8 +57,17 @@ pub struct EmittedEvent {
 /// the calling tool needs to bundle DB writes plus the event into a single atomic unit
 /// (e.g. setup::generate_world creating zones + emitting world.generated). The caller owns
 /// the transaction and must commit it.
+/// Hard cap on the `summary` text written to the events table. Several callers format
+/// user-influenced strings (condition names, effect sources, character names) into the
+/// summary via `format!`. A maliciously- or accidentally-long input would otherwise
+/// land verbatim in every event row, bloating the WAL and slowing recall queries.
+/// 1 KiB is comfortably above the longest legitimate summary in the codebase
+/// (`condition.applied`, `combat.apply_damage` etc. are all < 200 chars).
+const MAX_SUMMARY_BYTES: usize = 1024;
+
 pub fn emit_in_tx(tx: &Transaction<'_>, spec: &EventSpec<'_>) -> Result<EmittedEvent> {
     let payload = serde_json::to_string(&spec.payload).context("serialize payload")?;
+    let summary = truncate_summary(&spec.summary);
 
     tx.execute(
         "INSERT INTO events
@@ -71,7 +80,7 @@ pub fn emit_in_tx(tx: &Transaction<'_>, spec: &EventSpec<'_>) -> Result<EmittedE
             spec.zone_id,
             spec.encounter_id,
             spec.parent_id,
-            spec.summary,
+            summary,
             payload,
         ],
     )
@@ -114,6 +123,28 @@ pub fn emit(conn: &mut Connection, spec: &EventSpec<'_>) -> Result<EmittedEvent>
     let result = emit_in_tx(&tx, spec)?;
     tx.commit().context("commit event tx")?;
     Ok(result)
+}
+
+/// Cap `summary` to `MAX_SUMMARY_BYTES`, truncating on a UTF-8 char boundary so the
+/// resulting string is still valid (`String::truncate` panics on a non-boundary, and
+/// SQLite would happily store half a multi-byte sequence). If truncated, append a
+/// trailing `…` so a reader sees the cut-off rather than thinking the string ends mid-
+/// word. Operates on `&str` and returns owned only when truncation is needed.
+fn truncate_summary(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.len() <= MAX_SUMMARY_BYTES {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    // Find the last char boundary at or before MAX_SUMMARY_BYTES - 3 (room for "…",
+    // which is 3 UTF-8 bytes). is_char_boundary works on byte indices.
+    let target = MAX_SUMMARY_BYTES.saturating_sub(3);
+    let mut cut = target;
+    while cut > 0 && !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let mut out = String::with_capacity(MAX_SUMMARY_BYTES);
+    out.push_str(&s[..cut]);
+    out.push('…');
+    std::borrow::Cow::Owned(out)
 }
 
 #[cfg(test)]
@@ -255,5 +286,81 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn long_summary_is_truncated_with_ellipsis() {
+        // A pathological summary (e.g. someone passing a 1MB condition source name)
+        // shouldn't land verbatim in events.summary. The cap defends WAL size +
+        // recall query latency.
+        let mut conn = fresh_conn();
+        let kira = insert_character(&conn, "Kira");
+        let huge = "x".repeat(MAX_SUMMARY_BYTES + 200);
+        let spec = EventSpec {
+            kind: "test.long",
+            campaign_hour: 0,
+            combat_round: None,
+            zone_id: None,
+            encounter_id: None,
+            parent_id: None,
+            summary: huge.clone(),
+            payload: serde_json::json!({}),
+            participants: &[Participant {
+                character_id: kira,
+                role: "actor",
+            }],
+            items: &[],
+        };
+        let emitted = emit(&mut conn, &spec).expect("emit");
+
+        let stored: String = conn
+            .query_row(
+                "SELECT summary FROM events WHERE id = ?1",
+                [emitted.event_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            stored.len() <= MAX_SUMMARY_BYTES,
+            "stored summary {} bytes should fit under the cap {}",
+            stored.len(),
+            MAX_SUMMARY_BYTES
+        );
+        assert!(
+            stored.ends_with('…'),
+            "truncated summary should end with the ellipsis marker; got tail {:?}",
+            &stored[stored.len().saturating_sub(8)..]
+        );
+    }
+
+    #[test]
+    fn short_summary_passes_through_unchanged() {
+        let mut conn = fresh_conn();
+        let kira = insert_character(&conn, "Kira");
+        let short = "Short summary that should not be touched.";
+        let spec = EventSpec {
+            kind: "test.short",
+            campaign_hour: 0,
+            combat_round: None,
+            zone_id: None,
+            encounter_id: None,
+            parent_id: None,
+            summary: short.to_string(),
+            payload: serde_json::json!({}),
+            participants: &[Participant {
+                character_id: kira,
+                role: "actor",
+            }],
+            items: &[],
+        };
+        let emitted = emit(&mut conn, &spec).expect("emit");
+        let stored: String = conn
+            .query_row(
+                "SELECT summary FROM events WHERE id = ?1",
+                [emitted.event_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, short);
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -343,7 +343,10 @@ impl DmMcpHandler {
         &self,
         Parameters(params): Parameters<ApplyConditionParams>,
     ) -> Result<CallToolResult, McpError> {
-        with_db_mut(&self.db, |conn| conditions::apply(conn, params))
+        let content = Arc::clone(&self.content);
+        with_db_mut(&self.db, move |conn| {
+            conditions::apply(conn, &content, params)
+        })
     }
 
     #[tool(


### PR DESCRIPTION
Fixes #41.

## Summary

Four small validation gaps surfaced in the audit, each a few lines. Bundling because opening a separate PR per one-liner would be noise.

### 1. \`encounters::create\` — bail on negative xp_budget

\`src/encounters.rs:103\`. A negative xp_budget would flow to player_side participants on \`complete\`, deducting XP with no game-rules basis.

### 2. \`barter::derive_dc\` — handle NaN / Infinity

\`src/barter.rs:336\`. When \`requested_value == 0\`, \`ratio == f64::INFINITY\`. \`(INF * 100 / 10).ceil() as i32\` saturates at \`i32::MAX\`. NaN input was implementation-defined. Now clamps ratio to \`[0.0, 2.0]\` and treats NaN as \`FAIR_RATIO\` (fall back to base DC).

### 3. \`conditions::apply\` — validate against catalog

\`src/conditions.rs:67\`. A typo like \`paralised\` (vs the real \`paralyzed\`) used to silently insert a row whose mechanical riders never fired because \`resolve_check\` looks them up by name. Now bails with a message that names the offender and lists the valid set.

**Signature change**: \`apply\` now takes \`&Content\`. Updated:
- \`src/handler.rs\` — passes \`Arc::clone(&self.content)\` into the closure
- \`src/checks.rs\` — both test call sites now pass \`&content\`

### 4. \`events::emit_in_tx\` — cap summary length

\`src/events.rs\`. Multiple call sites format user-influenced strings (condition names, effect sources, character names) into the summary via \`format!\`. An attacker-supplied multi-MB source name would land verbatim in every event row, bloating the WAL and slowing recall queries.

Now: caps at \`MAX_SUMMARY_BYTES = 1024\`, truncating on a UTF-8 char boundary (so the resulting string is still valid UTF-8) and appending \`'…'\` so a reader can tell it was cut.

## Tests

Five new unit tests:
- \`encounters::tests::create_rejects_negative_xp_budget\`
- \`barter::tests::derive_dc_handles_nan_and_infinity_gracefully\`
- \`conditions::tests::apply_rejects_unknown_condition_name\`
- \`events::tests::long_summary_is_truncated_with_ellipsis\`
- \`events::tests::short_summary_passes_through_unchanged\`

## Test plan

- [x] \`cargo test --bin dm-mcp\` — 113 unit tests pass (was 109, +4 new tests, 0 regressions)
- [x] \`cargo clippy --bin dm-mcp -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean