### PR TITLE
combat: refuse apply_damage on dead characters (fixes #31)

### DIFF
--- a/src/combat.rs
+++ b/src/combat.rs
@@ -599,6 +599,18 @@ pub fn apply_damage(conn: &mut Connection, p: ApplyDamageParams) -> Result<Apply
         )
         .with_context(|| format!("character {} not found", p.character_id))?;
 
+    // Symmetric with apply_healing's dead-character guard (line 723). Without this,
+    // damage on a corpse silently clamped HP to 0 again and emitted a spurious
+    // damage event — confusing event-log analytics and letting a buggy or malicious
+    // caller spam the log. If a future tool wants "desecrate corpse" semantics it
+    // should be a separate event kind, not a silent overload of apply_damage.
+    if status == "dead" {
+        bail!(
+            "character {} is dead and cannot take damage",
+            p.character_id
+        );
+    }
+
     let new_hp = (hp_current - p.amount).max(0);
     let hits_zero = hp_current > 0 && new_hp == 0;
     let now = crate::world::current_campaign_hour(conn)?;

--- a/tests/combat.rs
+++ b/tests/combat.rs
@@ -597,6 +597,33 @@ async fn healing_dead_character_refused() -> Result<()> {
 }
 
 #[tokio::test]
+async fn damaging_dead_character_refused() -> Result<()> {
+    // Regression for #31: apply_damage on a corpse used to silently clamp HP to 0
+    // again and emit a spurious damage event. Now refuses, mirroring apply_healing.
+    use rmcp::model::CallToolRequestParams;
+
+    let h = connect().await?;
+    let player = make_char(&h.client, "Doomed", "player", 5).await?;
+    kill_character(&h.client, player).await?;
+
+    let args = serde_json::json!({ "character_id": player, "amount": 10 });
+    let params = CallToolRequestParams::new("combat.apply_damage")
+        .with_arguments(args.as_object().unwrap().clone());
+    let outcome = h.client.call_tool(params).await;
+    match outcome {
+        Err(_) => { /* JSON-RPC error — fine */ }
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "damaging dead character must signal error; got {result:?}"
+        ),
+    }
+
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn rest_long_refused_when_dead() -> Result<()> {
     use rmcp::model::CallToolRequestParams;
 


### PR DESCRIPTION
Fixes #31.

`combat::apply_damage` now bails when `status == 'dead'`, mirroring `apply_healing`'s existing guard at `src/combat.rs:723`.

Pre-fix, damage on a corpse silently clamped HP to 0 again and emitted a spurious `combat.apply_damage` event — confusing event-log analytics ("how many times was this character hit" got post-mortem counts) and letting a buggy or malicious caller spam the log.

If a future tool wants 'desecrate corpse' semantics it should be a separate event kind, not a silent overload of `apply_damage`.

E2E regression test in `tests/combat.rs::damaging_dead_character_refused` reuses the existing `kill_character` helper to set up a dead victim, then asserts `apply_damage` returns a structured tool error.

cargo test, cargo clippy --bin dm-mcp -- -D warnings, cargo fmt --check all clean.