### PR TITLE
inventory: harden transfer with destination, cycle, encumbrance checks (fixes #30)

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -684,7 +684,7 @@ pub fn inspect(conn: &Connection, content: &Content, item_id: i64) -> Result<Ite
 
 pub fn transfer(
     conn: &mut Connection,
-    _content: &Content,
+    content: &Content,
     p: TransferParams,
 ) -> Result<TransferResult> {
     let count = p.to_character_id.is_some() as u8
@@ -697,6 +697,81 @@ pub fn transfer(
     if p.to_container_item_id == Some(p.item_id) {
         bail!("cannot transfer item {} into itself", p.item_id);
     }
+
+    // Validate that the source item exists up front so the error message is precise
+    // ("item N does not exist") rather than the FK violation we'd hit at commit time.
+    let item = read_item(conn, p.item_id)?;
+
+    // Pre-check the destination so caller-facing errors name the missing referent
+    // ("destination character N does not exist") rather than the generic UPDATE
+    // failure path. Also detects container chain cycles (A → B → A).
+    if let Some(cid) = p.to_character_id {
+        let exists: bool = conn
+            .query_row("SELECT 1 FROM characters WHERE id = ?1", [cid], |_| {
+                Ok(true)
+            })
+            .optional()?
+            .unwrap_or(false);
+        if !exists {
+            bail!("destination character {cid} does not exist");
+        }
+    }
+    if let Some(ctid) = p.to_container_item_id {
+        let exists: bool = conn
+            .query_row("SELECT 1 FROM items WHERE id = ?1", [ctid], |_| Ok(true))
+            .optional()?
+            .unwrap_or(false);
+        if !exists {
+            bail!("destination container item {ctid} does not exist");
+        }
+        check_no_container_cycle(conn, ctid, p.item_id)?;
+    }
+    if let Some(zid) = p.to_zone_location_id {
+        let exists: bool = conn
+            .query_row("SELECT 1 FROM zones WHERE id = ?1", [zid], |_| Ok(true))
+            .optional()?
+            .unwrap_or(false);
+        if !exists {
+            bail!("destination zone {zid} does not exist");
+        }
+    }
+
+    // For character destinations, mirror pickup's overload guard. Without this,
+    // transfer is the asymmetric loophole that lets any character receive any item
+    // regardless of how heavy it is — silently ignoring the encumbrance contract that
+    // pickup enforces. Also pre-compute the post-transfer percentage so the encumbered
+    // condition gets the right state inside the tx.
+    let dest_char_overload: Option<(i64, f64, f64, i32)> = if let Some(cid) = p.to_character_id {
+        let (str_score,): (i32,) = conn
+            .query_row(
+                "SELECT str_score FROM characters WHERE id = ?1",
+                [cid],
+                |row| Ok((row.get(0)?,)),
+            )
+            .with_context(|| format!("character {cid} not found"))?;
+        let capacity = (str_score as f64) * (content.encumbrance.capacity_per_str as f64);
+        let item_weight = effective_weight_for_item(&item, content);
+        // If the item is already held by this character, transferring it back to them is
+        // a no-op weight-wise; only count weight when the holder actually changes.
+        let weight_delta = if item.holder_character_id == Some(cid) {
+            0.0
+        } else {
+            item_weight
+        };
+        let current_carried = carried_weight_lb(conn, content, cid)?;
+        let would_be = current_carried + weight_delta;
+        let overloaded_limit =
+            capacity * (content.encumbrance.overloaded_threshold_pct as f64) / 100.0;
+        if would_be > overloaded_limit {
+            bail!(
+                "transfer to character {cid} would overload them ({would_be:.2} lb carried of {capacity:.2} capacity); use inventory.pickup or drop weight first"
+            );
+        }
+        let would_pct = pct_of_capacity(would_be, capacity);
+        Some((cid, would_be, capacity, would_pct))
+    } else {
+        None
+    };
 
     let now = crate::world::current_campaign_hour(conn)?;
     let tx = conn.transaction().context("begin transfer tx")?;
@@ -752,11 +827,70 @@ pub fn transfer(
             }],
         },
     )?;
+    // For character destinations, recompute encumbrance inside the same tx so the
+    // 'encumbered' condition matches the post-transfer state. Mirrors the pickup path.
+    if let Some((cid, _would_be, _capacity, would_pct)) = dest_char_overload {
+        apply_encumbered_in_tx(&tx, content, cid, would_pct, now)?;
+    }
+    // Also re-evaluate the SOURCE holder's encumbrance if the item moved off a holder.
+    // Without this, removing weight from a previously-encumbered character wouldn't
+    // clear the condition.
+    if let Some(prev_holder) = item.holder_character_id {
+        if Some(prev_holder) != p.to_character_id {
+            // Recompute their carried weight + percentage post-transfer.
+            let (str_score,): (i32,) = tx
+                .query_row(
+                    "SELECT str_score FROM characters WHERE id = ?1",
+                    [prev_holder],
+                    |row| Ok((row.get(0)?,)),
+                )
+                .with_context(|| format!("source holder {prev_holder} disappeared"))?;
+            let capacity = (str_score as f64) * (content.encumbrance.capacity_per_str as f64);
+            let new_carried = carried_weight_lb(&tx, content, prev_holder)?;
+            let new_pct = pct_of_capacity(new_carried, capacity);
+            apply_encumbered_in_tx(&tx, content, prev_holder, new_pct, now)?;
+        }
+    }
     tx.commit().context("commit transfer tx")?;
     Ok(TransferResult {
         item_id: p.item_id,
         event_id: emitted.event_id,
     })
+}
+
+/// Walk the container chain upward from `start_container`, bailing if `item_being_moved`
+/// is already an ancestor (which would create a cycle once the move is applied) or if
+/// we exceed a safety depth. Lazy traversal — stops at the first NULL parent or root
+/// holder/zone reference.
+fn check_no_container_cycle(
+    conn: &Connection,
+    start_container: i64,
+    item_being_moved: i64,
+) -> Result<()> {
+    let mut current: Option<i64> = Some(start_container);
+    let mut steps: u32 = 0;
+    while let Some(cid) = current {
+        if cid == item_being_moved {
+            bail!(
+                "transferring item {item_being_moved} into container {start_container} would create a cycle (item is already an ancestor of the container)"
+            );
+        }
+        steps += 1;
+        if steps > 32 {
+            bail!(
+                "container chain depth from {start_container} exceeds 32 — refusing to walk further (probable existing cycle in data)"
+            );
+        }
+        current = conn
+            .query_row(
+                "SELECT container_item_id FROM items WHERE id = ?1",
+                [cid],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()?
+            .flatten();
+    }
+    Ok(())
 }
 
 fn describe_destination(p: &TransferParams) -> String {

--- a/tests/inventory.rs
+++ b/tests/inventory.rs
@@ -761,3 +761,164 @@ async fn non_stackable_create_with_quantity_errors() -> Result<()> {
     h.client.cancel().await?;
     Ok(())
 }
+
+// ── E2E 9: inventory.transfer destination/cycle/overload validation (#30) ──
+
+#[tokio::test]
+async fn transfer_to_nonexistent_character_returns_clear_error() -> Result<()> {
+    use rmcp::model::CallToolRequestParams;
+    let h = connect().await?;
+    let alice = make_char(&h.client, "Alice", 10, 10, None).await?;
+    let item = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "longsword", "holder_character_id": alice}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+
+    let args = serde_json::json!({"item_id": item, "to_character_id": 99_999});
+    let params = CallToolRequestParams::new("inventory.transfer")
+        .with_arguments(args.as_object().unwrap().clone());
+    let outcome = h.client.call_tool(params).await;
+    match outcome {
+        Err(e) => assert!(
+            format!("{e}").contains("does not exist"),
+            "JSON-RPC error should name the missing destination; got {e:?}"
+        ),
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "transferring to a nonexistent character must signal error; got {result:?}"
+        ),
+    }
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn transfer_into_self_via_container_chain_rejected() -> Result<()> {
+    // A → B → C; transferring A into C creates A → B → C → A. Walk parent chain
+    // upward from the destination, bail if we encounter the source.
+    use rmcp::model::CallToolRequestParams;
+    let h = connect().await?;
+    let alice = make_char(&h.client, "Alice", 10, 10, None).await?;
+    // Three nested containers: a → b → c (chain a->b means a is INSIDE b).
+    let a = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "heavy_crate", "holder_character_id": alice}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+    let b = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "heavy_crate", "holder_character_id": alice}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+    let c = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "heavy_crate", "holder_character_id": alice}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+
+    // Build the chain: put a inside b, then b inside c. (a's container = b; b's container = c.)
+    call(
+        &h.client,
+        "inventory.transfer",
+        serde_json::json!({"item_id": a, "to_container_item_id": b}),
+    )
+    .await?;
+    call(
+        &h.client,
+        "inventory.transfer",
+        serde_json::json!({"item_id": b, "to_container_item_id": c}),
+    )
+    .await?;
+
+    // Now try to put c inside a → would form a cycle (c → a → b → c).
+    let args = serde_json::json!({"item_id": c, "to_container_item_id": a});
+    let params = CallToolRequestParams::new("inventory.transfer")
+        .with_arguments(args.as_object().unwrap().clone());
+    let outcome = h.client.call_tool(params).await;
+    match outcome {
+        Err(e) => assert!(
+            format!("{e}").contains("cycle"),
+            "cycle error should be named explicitly; got {e:?}"
+        ),
+        Ok(result) => {
+            assert_eq!(result.is_error, Some(true), "got {result:?}");
+            let txt = result
+                .content
+                .iter()
+                .find_map(|c| match &c.raw {
+                    rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            // The structured tool error body or the message should mention "cycle".
+            assert!(
+                format!("{result:?}").contains("cycle") || txt.contains("cycle"),
+                "cycle error should be named; got result={result:?}, body={txt}"
+            );
+        }
+    }
+    h.client.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn transfer_to_overloaded_character_refused() -> Result<()> {
+    // Recipient is STR 10 (capacity 150 lb). A 100 lb crate already on them puts them
+    // at 66%. Transferring a SECOND 100 lb crate would push them to 200 lb / 150 = 133%
+    // — over the 100% overloaded threshold.
+    use rmcp::model::CallToolRequestParams;
+    let h = connect().await?;
+    let alice = make_char(&h.client, "Alice", 10, 10, None).await?;
+    let bob = make_char(&h.client, "Bob", 10, 10, None).await?;
+
+    let crate1 = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "heavy_crate", "holder_character_id": bob}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+    let crate2 = call(
+        &h.client,
+        "inventory.create",
+        serde_json::json!({"base_kind": "heavy_crate", "holder_character_id": alice}),
+    )
+    .await?["item_id"]
+        .as_i64()
+        .unwrap();
+    // Sanity: bob is holding crate1 already (66% of 150).
+    let _ = crate1;
+
+    let args = serde_json::json!({"item_id": crate2, "to_character_id": bob});
+    let params = CallToolRequestParams::new("inventory.transfer")
+        .with_arguments(args.as_object().unwrap().clone());
+    let outcome = h.client.call_tool(params).await;
+    match outcome {
+        Err(e) => assert!(
+            format!("{e}").contains("overload"),
+            "overload error should be named; got {e:?}"
+        ),
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "transferring to overloaded recipient must signal error; got {result:?}"
+        ),
+    }
+    h.client.cancel().await?;
+    Ok(())
+}


### PR DESCRIPTION
Fixes #30.

`inventory::transfer` was the most permissive write on the inventory surface — it let any caller move any item to any (validity-unchecked) destination with no encumbrance check, and only the trivial self-into-self cycle was caught. Three new guards bring it in line with pickup/drop:

## 1. Destination existence pre-check

For each of `to_character_id`, `to_container_item_id`, `to_zone_location_id`, run a small SELECT and bail with a clear error naming the missing referent ("destination character N does not exist") instead of letting the FK violation produce the generic "transfer item" message at commit time.

## 2. Container chain cycle detection

`check_no_container_cycle` walks the parent chain upward from the destination container via `container_item_id` (depth-capped at 32 as a safety net for pre-existing data cycles); bails if the item being moved is already an ancestor — would form a cycle (A → B → C → A) once the move applies.

## 3. Encumbrance recompute on character destinations

Mirrors `pickup`'s overload guard:
- compute the recipient's projected carried weight pre-tx; bail with an explicit overload error if it crosses `overloaded_threshold_pct`
- inside the tx, call `apply_encumbered_in_tx` for **both** the destination AND the source holder, so dropping weight off a previously-encumbered character clears their condition

## Tests

Three new e2e regression tests in `tests/inventory.rs`:
- `transfer_to_nonexistent_character_returns_clear_error`
- `transfer_into_self_via_container_chain_rejected` — builds a 3-deep chain (a→b→c) and asserts c→a is rejected
- `transfer_to_overloaded_character_refused` — Bob holds a 100lb crate (66% of 150), Alice transfers a second crate that would push him to 133%

## Test plan

- [x] `cargo test --test inventory transfer` — 4 pass
- [x] `cargo clippy --bin dm-mcp -- -D warnings` clean
- [x] `cargo fmt --check` clean