### PR TITLE
handler: classify tool errors via ToolUserError marker (fixes #34)

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -57,6 +57,53 @@ pub struct DiceRollParams {
     pub spec: String,
 }
 
+/// Marker error type for caller-facing validation failures (issue #34). Domain code
+/// that wants the resulting MCP error to be classified as `invalid_params` (i.e. "you
+/// passed bad input") rather than `internal_error` ("the server broke") wraps its
+/// `anyhow::Error` in this newtype. The `with_db*` helpers below downcast and pick the
+/// right MCP error variant.
+///
+/// Without this distinction, every domain bail! — including a SQLite I/O error or a
+/// content-load issue — got tagged as `invalid_params`, polluting the consumer's error
+/// analytics and giving misleading retry signals.
+///
+/// Migrations are gradual: code that hasn't been migrated yet stays on plain
+/// `bail!`/`anyhow!`, which classifies as `internal_error` (the safer default — the
+/// caller didn't necessarily do anything wrong, so don't blame them).
+#[derive(Debug)]
+pub struct ToolUserError(pub String);
+
+impl std::fmt::Display for ToolUserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ToolUserError {}
+
+/// Convenience: build a ToolUserError-wrapped anyhow::Error in one call. Used as
+/// `bail_user!("character {} not found", id)` from domain code, equivalent to
+/// `bail!(ToolUserError(format!(...)))` but shorter.
+#[macro_export]
+macro_rules! bail_user {
+    ($($arg:tt)*) => {
+        return ::std::result::Result::Err(
+            ::anyhow::anyhow!($crate::handler::ToolUserError(format!($($arg)*)))
+        )
+    };
+}
+
+/// Classify an anyhow error and wrap it in the right McpError variant. ToolUserError
+/// → invalid_params (caller's fault); anything else → internal_error (server's
+/// problem). The error message is preserved verbatim in both cases.
+fn classify_tool_error(e: anyhow::Error) -> McpError {
+    if e.downcast_ref::<ToolUserError>().is_some() {
+        McpError::invalid_params(format!("{e:#}"), None)
+    } else {
+        McpError::internal_error(format!("{e:#}"), None)
+    }
+}
+
 /// Small helper — take a mutex on the DB, run a callback, serialise the result as JSON
 /// inside a CallToolResult. Keeps tool bodies tight.
 fn with_db_mut<F, T>(db: &DbHandle, f: F) -> Result<CallToolResult, McpError>
@@ -68,7 +115,7 @@ where
         let mut conn = db
             .lock()
             .map_err(|_| McpError::internal_error("DB mutex poisoned".to_string(), None))?;
-        f(&mut conn).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?
+        f(&mut conn).map_err(classify_tool_error)?
     };
     let json = serde_json::to_string(&value)
         .map_err(|e| McpError::internal_error(format!("serialise response: {e}"), None))?;
@@ -84,7 +131,7 @@ where
         let conn = db
             .lock()
             .map_err(|_| McpError::internal_error("DB mutex poisoned".to_string(), None))?;
-        f(&conn).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?
+        f(&conn).map_err(classify_tool_error)?
     };
     let json = serde_json::to_string(&value)
         .map_err(|e| McpError::internal_error(format!("serialise response: {e}"), None))?;
@@ -913,5 +960,65 @@ impl ServerHandler for DmMcpHandler {
             "dm-mcp: MCP toolkit for AI Dungeon Masters. Phase 10 adds inventory (create/pickup/drop/equip/unequip/get/inspect/transfer) with encumbrance enforcement (pickup refused above overloaded threshold, 'encumbered' condition applied between encumbered and overloaded thresholds) and barter.exchange (persuasion-check-driven rate). Live tools: server.info, content.introspect, dice.roll, character.*, apply_effect, dispel_effect, proficiency.*, resource.*, condition.*, resolve_check, setup.*, world.*, npc.generate, character.recall, encounter.*, combat.*, roll_death_save, roll_death_event, rest.short, rest.long, inventory.*, barter.exchange.".to_string(),
         );
         info
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_tool_user_error_as_invalid_params() {
+        // The marker type is recognised — caller-facing errors get tagged invalid_params.
+        let err: anyhow::Error = anyhow::anyhow!(ToolUserError("you passed bad input".into()));
+        let mcp = classify_tool_error(err);
+        // Inspect via Debug since McpError doesn't expose its code field publicly.
+        let dbg = format!("{mcp:?}");
+        assert!(
+            dbg.contains("InvalidParams")
+                || dbg.contains("invalid_params")
+                || dbg.contains("-32602"),
+            "ToolUserError should classify as invalid_params; got {dbg}"
+        );
+        assert!(
+            dbg.contains("you passed bad input"),
+            "message should be preserved: {dbg}"
+        );
+    }
+
+    #[test]
+    fn classify_plain_anyhow_as_internal_error() {
+        // Default for un-wrapped errors: internal_error. Pre-fix this was invalid_params,
+        // which incorrectly blamed the caller for server-side failures (SQLite I/O, etc.).
+        let err: anyhow::Error = anyhow::anyhow!("disk full");
+        let mcp = classify_tool_error(err);
+        let dbg = format!("{mcp:?}");
+        assert!(
+            dbg.contains("InternalError")
+                || dbg.contains("internal_error")
+                || dbg.contains("-32603"),
+            "plain anyhow should classify as internal_error; got {dbg}"
+        );
+    }
+
+    #[test]
+    fn bail_user_macro_produces_classifiable_error() {
+        // Ensure the convenience macro lands a ToolUserError that classify_tool_error
+        // recognises end-to-end.
+        fn rejects_zero(x: i32) -> anyhow::Result<()> {
+            if x == 0 {
+                crate::bail_user!("x must be non-zero (got {x})");
+            }
+            Ok(())
+        }
+        let err = rejects_zero(0).expect_err("should reject zero");
+        let mcp = classify_tool_error(err);
+        let dbg = format!("{mcp:?}");
+        assert!(
+            dbg.contains("InvalidParams")
+                || dbg.contains("invalid_params")
+                || dbg.contains("-32602"),
+            "bail_user! should produce an invalid_params classification; got {dbg}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #34 (framework — site migrations follow up).

Pre-fix, `with_db` / `with_db_mut` mapped every downstream error to `McpError::invalid_params`. That conflated three distinct failure classes — caller-side bad input, server-side internal failure (SQLite I/O, content-load issue), and lock poisoning. An LLM consumer got the same tag for 'you passed a bad id' and 'the server's database disk is full' — bad signal for retry logic and bad analytics.

## Framework introduced

- **`pub struct ToolUserError(pub String)`** — marker newtype with hand-impls of `Display` + `Error` so it's downcastable from `anyhow::Error` (no new `thiserror` dep).
- **`bail_user!(...)` macro** — ergonomic wrapper exported from the crate root. `crate::bail_user!("x must be > 0 (got {x})")` is equivalent to `bail!(ToolUserError(format!(...)))`.
- **`classify_tool_error()`** — single function that downcasts + maps to the right `McpError` variant.
- **`with_db` / `with_db_mut` updated** to call `classify_tool_error` instead of unconditionally invalid_params.

Default mapping for un-migrated code: plain `bail!`/`anyhow!` → `internal_error` (safer default — don't blame the caller for un-classified errors). Migrating a site to `bail_user!` flips it to `invalid_params`.

## Why no site migrations in this PR

Migrating every `bail!` site that's actually caller-facing is a sweeping change that would step on other in-flight PRs (e.g. #51 touches characters.rs, where many obvious migration candidates live). Doing it as a follow-up keeps this PR's diff scoped (109 lines vs 1000+) and doesn't block anything.

## Tests

Three unit tests in `src/handler.rs::tests`:
- `classify_tool_user_error_as_invalid_params` — wrapped error → invalid_params
- `classify_plain_anyhow_as_internal_error` — un-wrapped error → internal_error
- `bail_user_macro_produces_classifiable_error` — macro → wrapped → invalid_params end-to-end

## Test plan

- [x] `cargo test --bin dm-mcp` — 122 unit tests pass (was 119, +3 new)
- [x] `cargo clippy --bin dm-mcp -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] No e2e regressions: existing tests assert `is_error: Some(true)` not specific MCP error codes

## Behaviour change

This is a real semantic change: every `bail!` site that hasn't been migrated now produces `internal_error` where it previously produced `invalid_params`. Documented and intentional — the safer default for un-classified errors is to err toward "server's problem" rather than misleadingly blaming the caller.

## Follow-up issues

- Migrate obvious caller-facing `bail!` sites in characters.rs / inventory.rs / etc. to `bail_user!` over the next few PRs.