### PR TITLE
tests: extract shared MCP harness to tests/common/mod.rs (fixes #38)

### DIFF
--- a/tests/character_core.rs
+++ b/tests/character_core.rs
@@ -9,66 +9,10 @@
 //! Additional tests cover update_plans / change_role / proficiencies / resources.
 
 use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-/// Invoke a tool with the given JSON args and parse the text payload as JSON.
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 /// Collect every event kind that referenced the given character, in insertion order. Reads
 /// the SQLite file directly — the server is still running but SQLite's WAL mode lets a

--- a/tests/checks.rs
+++ b/tests/checks.rs
@@ -7,65 +7,10 @@
 //!    with its reason.
 
 use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 /// Read the latest event of a given kind by character_id, returning its payload as JSON.
 fn latest_event_payload(

--- a/tests/combat.rs
+++ b/tests/combat.rs
@@ -9,65 +9,10 @@
 //!   emitted.
 
 use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 async fn make_char(
     client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,102 @@
+//! Shared test harness for MCP integration tests.
+//!
+//! Cargo's special-cases `tests/common/mod.rs` (and any other path that isn't a top-level
+//! `.rs` file directly under `tests/`) as a non-test module, so each integration test
+//! file can `mod common;` to pull in the harness without producing a "tests/common.rs
+//! has no tests" warning.
+//!
+//! What lives here:
+//!
+//! - [`bin_path`] — looks up the compiled `dm-mcp` binary via `CARGO_BIN_EXE_dm-mcp`.
+//! - [`Harness`] — bundles a per-test `TempDir` (auto-deleted on drop), the resulting
+//!   `db_path`, and the running rmcp client.
+//! - [`connect`] — spawns the binary as a stdio MCP child and returns a [`Harness`].
+//! - [`call`] — invokes a tool and parses the response text as JSON, asserting the
+//!   tool didn't signal `is_error: true`.
+//!
+//! What does NOT live here:
+//!
+//! - Per-file helpers like `make_char` (different signatures per test file's needs)
+//!   and `setup_world` (per-file orchestration of the campaign-setup flow). Those stay
+//!   in their respective test files.
+//!
+//! Each test that needs the harness adds two lines at the top:
+//!
+//! ```text
+//! mod common;
+//! use common::{call, connect, Harness};
+//! ```
+
+#![allow(dead_code)] // not every test file uses every helper
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::transport::TokioChildProcess;
+use rmcp::ServiceExt;
+use tempfile::TempDir;
+use tokio::process::Command;
+
+/// Path to the compiled `dm-mcp` binary. Cargo defines `CARGO_BIN_EXE_<name>` for
+/// integration tests of binary crates, so no manual lookup is needed.
+pub fn bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
+}
+
+/// MCP test harness. The `_tmp` TempDir is held to keep the campaign DB on disk for
+/// the duration of the test; dropping it on test exit deletes the file.
+pub struct Harness {
+    pub _tmp: TempDir,
+    pub db_path: PathBuf,
+    pub client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
+}
+
+/// Spawn the `dm-mcp` binary as a stdio MCP child and complete the rmcp handshake.
+/// Each call gets its own TempDir-backed campaign DB so tests can run in parallel
+/// without racing on schema migration.
+pub async fn connect() -> Result<Harness> {
+    let tmp = TempDir::new()?;
+    let db_path = tmp.path().join("campaign.db");
+    let mut cmd = Command::new(bin_path());
+    cmd.arg("stdio");
+    cmd.env("DMMCP_LOG_LEVEL", "warn");
+    cmd.env("DMMCP_DB_PATH", &db_path);
+    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
+    let client = ().serve(transport).await.context("mcp handshake")?;
+    Ok(Harness {
+        _tmp: tmp,
+        db_path,
+        client,
+    })
+}
+
+/// Invoke a tool with the given JSON args and parse the text payload as JSON. Asserts
+/// the tool didn't signal `is_error: true` — tests that expect an error path should
+/// call `client.call_tool(...)` directly and inspect the result.
+pub async fn call(
+    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
+    name: &str,
+    args: serde_json::Value,
+) -> Result<serde_json::Value> {
+    let obj = args.as_object().cloned().unwrap_or_default();
+    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
+    let result = client
+        .call_tool(params)
+        .await
+        .with_context(|| format!("call {name}"))?;
+    assert!(
+        result.is_error != Some(true),
+        "{name} signalled error: {:?}",
+        result
+    );
+    let text = result
+        .content
+        .iter()
+        .find_map(|item| match &item.raw {
+            RawContent::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .context("expected text content")?;
+    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
+}

--- a/tests/inventory.rs
+++ b/tests/inventory.rs
@@ -7,66 +7,11 @@
 //!   `would_overload`. Barter: offer below fair value → persuasion check → success
 //!   completes, failure → merchant declines.
 
-use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
+use anyhow::Result;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    _db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        _db_path: db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 async fn make_char(
     client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,

--- a/tests/npcs.rs
+++ b/tests/npcs.rs
@@ -8,65 +8,10 @@
 //!   `character.recall(orc.id)` returns those events.
 
 use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 /// Run new → starting_biome → generate_world → mark_ready so we have a live zone to drop
 /// an NPC into. Returns the starting zone id.

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -7,65 +7,10 @@
 //! - `campaign.started` event recorded at `campaign_hour = 0`.
 
 use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 #[tokio::test]
 async fn full_setup_flow_lands_in_running_with_world_in_place() -> Result<()> {

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -4,66 +4,11 @@
 //! `character_zone_knowledge.level` = 'visited', `world.map` returns both zones with
 //! computed 2D positions and connection.
 
-use anyhow::{Context, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
-use rmcp::transport::TokioChildProcess;
-use rmcp::ServiceExt;
+use anyhow::Result;
 use rusqlite::Connection;
-use tempfile::TempDir;
-use tokio::process::Command;
 
-fn bin_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_dm-mcp"))
-}
-
-struct Harness {
-    _tmp: TempDir,
-    db_path: std::path::PathBuf,
-    client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-}
-
-async fn connect() -> Result<Harness> {
-    let tmp = TempDir::new()?;
-    let db_path = tmp.path().join("campaign.db");
-    let mut cmd = Command::new(bin_path());
-    cmd.arg("stdio");
-    cmd.env("DMMCP_LOG_LEVEL", "warn");
-    cmd.env("DMMCP_DB_PATH", &db_path);
-    let transport = TokioChildProcess::new(cmd).context("spawn child")?;
-    let client = ().serve(transport).await.context("mcp handshake")?;
-    Ok(Harness {
-        _tmp: tmp,
-        db_path,
-        client,
-    })
-}
-
-async fn call(
-    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
-    name: &str,
-    args: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let obj = args.as_object().cloned().unwrap_or_default();
-    let params = CallToolRequestParams::new(name.to_string()).with_arguments(obj);
-    let result = client
-        .call_tool(params)
-        .await
-        .with_context(|| format!("call {name}"))?;
-    assert!(
-        result.is_error != Some(true),
-        "{name} signalled error: {:?}",
-        result
-    );
-    let text = result
-        .content
-        .iter()
-        .find_map(|item| match &item.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
-            _ => None,
-        })
-        .context("expected text content")?;
-    serde_json::from_str(&text).with_context(|| format!("{name} payload: {text}"))
-}
+mod common;
+use common::{call, connect};
 
 /// Bring a campaign up to "running" with a character placed in the starting zone.
 /// Returns (player_id, starting_zone_id, neighbour_ids).


### PR DESCRIPTION
Fixes #38.

The MCP test harness — `bin_path()` + `Harness` struct + `connect()` + `call()` — was duplicated across 7 integration test files. ~60 lines × 7 = 420 duplicated lines. Drift was already showing (`inventory.rs` had `_db_path` where others had `db_path`).

## Fix

Cargo treats `tests/common/mod.rs` as a non-test module shared across integration test binaries. Each test file now does:

```rust
mod common;
use common::{call, connect};
```

Net change: **-284 lines**. `tests/common/mod.rs` is 102 lines (well-doc'd); the 7 test files each lose ~60 lines.

## What's NOT extracted

Per-file specifics that vary (`make_char` with different signatures, `setup_world` bootstrap, `kill_character` helper, `latest_event_payload` DB inspector) **stay in their respective files** — extraction would require parametrising every helper or accepting the variation as harness divergence.

Test files NOT touched:
- `tests/healthz.rs` (uses TCP / reqwest, not rmcp client harness)
- `tests/dice.rs` (simpler `call_roll` wrapper)
- `tests/content_introspect.rs` (`connect_with_db` variant)
- `tests/schema.rs` (spawns HTTP child for schema inspection)
- `tests/stdio_server_info.rs` (minimal helpers)

These could each get `tests/common` helpers in follow-ups, but their patterns vary enough that the simple shape doesn't fit cleanly.

## Test plan

- [x] All 13 test binaries pass without modification (behavior unchanged)
- [x] `cargo build --tests` clean (zero warnings after dropping no-longer-used `Context` imports from world.rs / inventory.rs)
- [x] `cargo fmt --check` clean
- [x] No clippy warnings introduced

## Out of scope

Migrating the remaining test files to use `tests/common/` — separable follow-up.